### PR TITLE
fixes how mutate brings in columns if they are selected as table.name

### DIFF
--- a/src/TBD_macros.jl
+++ b/src/TBD_macros.jl
@@ -21,7 +21,7 @@ macro select(sqlquery, exprs...)
                     for idx in eachindex($(esc(sqlquery)).metadata.current_selxn)
                         if $(esc(sqlquery)).metadata.table_name[idx] == table_name && 
                            $(esc(sqlquery)).metadata.name[idx] == col_name
-                            $(esc(sqlquery)).metadata.current_selxn[idx] = 1
+                            $(esc(sqlquery)).metadata.current_selxn[idx] = 2
                         end
                     end
                 else
@@ -226,7 +226,10 @@ macro mutate(sqlquery, mutations...)
             #else
             #select_expressions = !isempty(sq.select) && sq.select != "*" ? [sq.select] : ["*"]
             #end
-            all_columns = sq.metadata[sq.metadata.current_selxn .== 1, :name]
+            all_columns = [
+                (row[:current_selxn] == 1 ? row[:name] : row[:table_name] * "." * row[:name])
+                for row in eachrow(sq.metadata) if row[:current_selxn] != 0
+            ]            
             select_expressions = [col for col in all_columns]  # Start with all currently selected columns
 
             for expr in $mutations

--- a/src/joins_sq.jl
+++ b/src/joins_sq.jl
@@ -34,9 +34,6 @@ macro left_join(sqlquery, join_table, lhs_column, rhs_column)
                 join_clause = " LEFT JOIN " * string($(esc(join_table))) * " ON " * string($(esc(join_table)), ".", $lhs_col_str, " = ", sq.from, ".", $rhs_col_str)
                 sq.from *= join_clause
 
-                # Update metadata to include columns from the joined table
-                new_metadata = get_table_metadata(sq.db, string($(esc(join_table))))
-                sq.metadata = vcat(sq.metadata, new_metadata)
             end
             
             # Update metadata to include columns from the joined table


### PR DESCRIPTION
mutate was not honoring columns written as table.name in select and rewriting them as name. this is now fixed

Also fixes left_join double adding metadata of new table. 