### PR TITLE
fixes get_metadata to be name agnostic for MySQL/MariaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The main goal of TidierDB.jl is to bring the syntax of Tidier.jl to multiple SQL
 - DuckDB (the default) `set_sql_mode(:duckdb)`
 - ClickHouse `set_sql_mode(:clickhouse)`
 - SQLite `set_sql_mode(:lite)`
-- MySQL `set_sql_mode(:mysql)`
+- MySQL and MariaDB `set_sql_mode(:mysql)`
 - MSSQL `set_sql_mode(:mssql)`
 - Postgres `set_sql_mode(:postgres)`
 

--- a/docs/examples/UserGuide/getting_started.jl
+++ b/docs/examples/UserGuide/getting_started.jl
@@ -12,7 +12,7 @@
 # The associated databased packages used to set up connections are currently as follows
 
 # - ClickHouse: ClickHouse.jl
-# - MySQL: MySQL.jl
+# - MySQL and MariaDB: MySQL.jl
 # - MSSQL:  ODBC.jl 
 # - Postgres: LibPQ.jl
 # - SQLite: SQLite.jl

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,7 +11,7 @@ The main goal of TidierDB.jl is to bring the syntax of Tidier.jl to multiple SQL
 - DuckDB (the default) `set_sql_mode(:duckdb)`
 - ClickHouse `set_sql_mode(:clickhouse)`
 - SQLite `set_sql_mode(:lite)`
-- MySQL `set_sql_mode(:mysql)`
+- MySQL and MariaDB `set_sql_mode(:mysql)`
 - MSSQL `set_sql_mode(:mssql)`
 - Postgres `set_sql_mode(:postgres)`
 

--- a/src/TidierDB.jl
+++ b/src/TidierDB.jl
@@ -176,15 +176,16 @@ function get_table_metadata(conn::MySQL.Connection, table_name::String)
     SELECT column_name, data_type
     FROM information_schema.columns
     WHERE table_name = '$table_name'
+    AND TABLE_SCHEMA = '$(conn.db)'
     ORDER BY ordinal_position;
     """
 
     result = DBInterface.execute(conn, query) |> DataFrame
-    result[!, :DATA_TYPE] = map(x -> String(x), result.DATA_TYPE)
+    result[!, 2] = map(x -> String(x), result[!, 2])
     result[!, :current_selxn] .= 1
     result[!, :table_name] .= table_name
     # Adjust the select statement to include the new table_name column
-    return select(result, :COLUMN_NAME => :name, 2 => :type, :current_selxn, :table_name)
+    return DataFrames.select(result, :1 => :name, 2 => :type, :current_selxn, :table_name)
 end
 
 # MSSQL


### PR DESCRIPTION
fixes issues with different cases (caps vs lowercase) in column names for mariaDB and MySQL metadata #11 