### PR TITLE
adds s3 support w duckdb, improves `db_table`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # TidierDB.jl updates
 
-## v0.2.2 - 2024-07-08
+## v0.2.2 - 2024-07-07
 - Adds direct path support for `db_table` when using DuckDB
 - Adds `connect` ability for AWS and Google Cloud to allow querying via S3 + DuckDB 
 - Adds documentation for S3 + DuckDB with TidierDB

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # TidierDB.jl updates
 
+## v0.2.2 - 2024-07-08
+- Adds direct path support for `db_table` when using DuckDB
+- Adds `connect` ability for AWS and Google Cloud to allow querying via S3 + DuckDB 
+- Adds documentation for S3 + DuckDB with TidierDB
+
 ## v0.2.1 - 2024-06-27
 - Adds support for Databricks SQL Rest API
 - Adds docs for Databricks use

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TidierDB"
 uuid = "86993f9b-bbba-4084-97c5-ee15961ad48b"
 authors = ["Daniel Rizk <rizk.daniel.12@gmail.com> and contributors"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/docs/examples/UserGuide/s3viaduckdb.jl
+++ b/docs/examples/UserGuide/s3viaduckdb.jl
@@ -1,0 +1,36 @@
+# TidierDB allows you leverage DuckDB's seamless database integration.
+
+# Using DuckDB, you can connect to an AWS or GoogleCloud Database to query directly without making any local copies. 
+# 
+# ```julia
+# Using TidierDB
+# 
+# #Connect to Google Cloud via DuckDB
+# #google_db = connect(:duckdb, :gbq, access_key="string", secret_key="string")
+# #Connect to AWS via DuckDB
+# aws_db = connect2(:duckdb, :aws, aws_access_key_id=get(ENV, "AWS_ACCESS_KEY_ID", "access_key"), aws_secret_access_key=get(ENV, "AWS_SECRET_ACCESS_KEY", "secret_access key"), aws_region=get(ENV, "AWS_DEFAULT_REGION", "us-east-1"))
+# s3_csv_path = "s3://path/to_data.csv"
+
+# @chain db_table(aws_db, s3_csv_path) begin
+#     @filter(!starts_with(column1, "M"))
+#     @group_by(cyl)
+#     @summarize(mpg = mean(mpg))
+#     @mutate(mpg_squared = mpg^2, 
+#                mpg_rounded = round(mpg), 
+#                mpg_efficiency = case_when(
+#                                  mpg >= cyl^2 , "efficient",
+#                                  mpg < 15.2 , "inefficient",
+#                                  "moderate"))            
+#     @filter(mpg_efficiency in ("moderate", "efficient"))
+#     @arrange(desc(mpg_rounded))
+#     @collect
+# end
+# ```
+# ```
+# 2×5 DataFrame
+#  Row │ cyl     mpg       mpg_squared  mpg_rounded  mpg_efficiency 
+#      │ Int64?  Float64?  Float64?     Float64?     String?        
+# ─────┼────────────────────────────────────────────────────────────
+#    1 │      4   27.3444      747.719         27.0  efficient
+#    2 │      6   19.7333      389.404         20.0  moderate
+# ```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -119,7 +119,7 @@ nav:
   - "Key Differences from TidierData.jl" : "examples/generated/UserGuide/key_differences.md"
   - "Getting Started" : "examples/generated/UserGuide/getting_started.md"
   - "Reusing Part of a Query" : "examples/generated/UserGuide/from_queryex.md"
-  - "S3 + DuckDB + TidierDB" : "examples/UserGuide/s3viaduckdb.md"
+  - "S3 + DuckDB + TidierDB" : "examples/generated/UserGuide/s3viaduckdb.md"
   - "Using Athena" : "examples/generated/UserGuide/athena.md"
   - "Using Snowflake" : "examples/generated/UserGuide/Snowflake.md"
   - "Using Databricks" : "examples/generated/UserGuide/databricks.md"

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -119,7 +119,7 @@ nav:
   - "Key Differences from TidierData.jl" : "examples/generated/UserGuide/key_differences.md"
   - "Getting Started" : "examples/generated/UserGuide/getting_started.md"
   - "Reusing Part of a Query" : "examples/generated/UserGuide/from_queryex.md"
-  - "S3+DuckDB+TidierDB" : "examples/UserGuide/s3viaduckdb.jl"
+  - "S3 + DuckDB + TidierDB" : "examples/UserGuide/s3viaduckdb.md"
   - "Using Athena" : "examples/generated/UserGuide/athena.md"
   - "Using Snowflake" : "examples/generated/UserGuide/Snowflake.md"
   - "Using Databricks" : "examples/generated/UserGuide/databricks.md"

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
   - "Key Differences from TidierData.jl" : "examples/generated/UserGuide/key_differences.md"
   - "Getting Started" : "examples/generated/UserGuide/getting_started.md"
   - "Reusing Part of a Query" : "examples/generated/UserGuide/from_queryex.md"
+  - "S3+DuckDB+TidierDB" : "examples/UserGuide/s3viaduckdb.jl"
   - "Using Athena" : "examples/generated/UserGuide/athena.md"
   - "Using Snowflake" : "examples/generated/UserGuide/Snowflake.md"
   - "Using Databricks" : "examples/generated/UserGuide/databricks.md"

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -988,6 +988,11 @@ This function establishes a database connection based on the specified backend a
 # conn = connect(:snowflake, "ac_id", "token", "Database_name", "Schema_name", "warehouse_name")
 # Connect to DuckDB
 julia> db = connect(:duckdb)
+# connect to Google Cloud via DuckDB
+# google_db = connect(:duckdb, :gbq, access_key="string", secret_key="string")
+# Connect to AWS via DuckDB
+# aws_db = connect2(:duckdb, :aws, aws_access_key_id=get(ENV, "AWS_ACCESS_KEY_ID", "access_key"), aws_secret_access_key=get(ENV, "AWS_SECRET_ACCESS_KEY", "secret_access key"), aws_region=get(ENV, "AWS_DEFAULT_REGION", "us-east-1"))
+
 DuckDB.Connection(":memory:")
 """
 


### PR DESCRIPTION
- allows `db_table` to directly support paths locally or from s3 source like Google Cloud or AWS
- enables use of duckdb + s3 in tidierdb. probably couldve done this in lieu of adding AWS.jl and GoogleCloud as dependencies.. but now users have 2 options 
- adds docs around using duckdb + s3 with tidierdb