### PR TITLE
add single col joinsyntax, 4th if_else arg

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # TidierDB.jl updates
-## v0.5.1 - 2024-10-29
+## v0.5.1 - 2024-11-08
+- support for [reusing TidierDB queries](https://tidierorg.github.io/TidierDB.jl/latest/examples/generated/UserGuide/functions_pass_to_DB/#interpolating-queries) inside other macros, including `@mutate`, `@filter`, `@summarize`
 - adds `@union_all` to bind all rows not just distinct rows as with `@union`
 - joining syntax now supports `(table1, table2, col_name)` when joining columns have shared name
 - `if_else` now has optional final argument for handling missing values to match TidierData

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,10 @@
 # TidierDB.jl updates
+## v0.5.1 - 2024-10-29
+- adds `@union_all` to bind all rows not just distinct rows as with `@union`
+- joining syntax now supports `(table1, table2, col_name)` when joining columns have shared name
+- `if_else` now has optional final argument for handling missing values to match TidierData
+
+# TidierDB.jl updates
 ## v0.5.0 - 2024-10-15
 Breaking Changes: 
 - All join syntax now matches TidierData's `(table1, table2, t1_col = t2_col)`

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TidierDB"
 uuid = "86993f9b-bbba-4084-97c5-ee15961ad48b"
 authors = ["Daniel Rizk <rizk.daniel.12@gmail.com> and contributors"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ TidierDB.jl currently supports the following top-level macros:
 | **Category**                     | **Supported Macros and Functions**                                                                                                                                               |
 |----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Data Manipulation**     | `@arrange`, `@group_by`, `@filter`, `@select`, `@mutate` (supports `across`), `@summarize`/`@summarise` (supports `across`), `@distinct`                                 |
-| **Joining**                  | `@left_join`, `@right_join`, `@inner_join`, `@anti_join`, `@full_join`, `@semi_join`, `@union`                                          |
+| **Joining**                  | `@left_join`, `@right_join`, `@inner_join`, `@anti_join`, `@full_join`, `@semi_join`, `@union`, `@union_all`                                         |
 | **Slice and Order**       | `@slice_min`, `@slice_max`, `@slice_sample`, `@order`, `@window_order`, `@window_frame`                                                                                                |
 | **Utility**               | `@show_query`, `@collect`, `@head`, `@count`, `show_tables`, `@create_view` , `drop_view`                                                                                                                                          |
 | **Helper Functions**             | `across`, `desc`, `if_else`, `case_when`, `n`, `starts_with`, `ends_with`, `contains`, `as_float`, `as_integer`, `as_string`, `is_missing`, `missing_if`, `replace_missing` |

--- a/docs/examples/UserGuide/duckplyr_reprex.jl
+++ b/docs/examples/UserGuide/duckplyr_reprex.jl
@@ -29,7 +29,7 @@
 # ```julia
 # @chain DB.t(data) begin
 #   DB.@filter(str_detect(count, r"^\d+$")) 
-#   DB.@mutate(count_ = "TRY_CAST(count AS INT)") 
+#   DB.@mutate(count_ = as_integer(count)) 
 #   DB.@filter(count_ > 0) 
 #   DB.@inner_join(
 #     (@chain DB.t(age) begin 

--- a/docs/examples/UserGuide/functions_pass_to_DB.jl
+++ b/docs/examples/UserGuide/functions_pass_to_DB.jl
@@ -19,7 +19,7 @@ df_mem = db_table(db, "dfm");
 num = [3]; 
 column = :id;
 @eval @chain t(df_mem) begin
-        @filter(value in $num) 
+        @filter(value < $num) 
         @select($column)
         @collect
     end
@@ -28,7 +28,7 @@ column = :id;
 # Begin by defining your function as your normally would, but before `@chain` you need to use `@eval`. For the variables to be interpolated in need to be started with `$`
 function test(vals, cols)
     @eval @chain t(df_mem) begin
-        @filter(value in $vals) 
+        @filter(value < $vals) 
         @select($cols)
         @collect
     end

--- a/docs/examples/UserGuide/functions_pass_to_DB.jl
+++ b/docs/examples/UserGuide/functions_pass_to_DB.jl
@@ -88,19 +88,19 @@ end
 
 # ## Interpolating queries
 # To use a prior, uncollected TidierDB query in other TidierDB macros, interpolate the needed query without showing or collecting it 
-ok = @chain t(test_db) @summarize(mean = mean(value));
+ok = @chain t(df_mem) @summarize(mean = mean(value));
 # the mean value represented in SQL from the above is 3
-@eval @chain t(test_db) begin 
+@eval @chain t(df_mem) begin 
     @filter( value > $ok) 
     @collect 
 end
 
-@eval @chain t(test_db) begin 
+@eval @chain t(df_mem) begin 
     @mutate(value2 =  value + $ok) 
     @collect 
 end
 
-@eval @chain t(test_db) begin 
+@eval @chain t(df_mem) begin 
     @summarize(value =  mean(value) * $ok) 
     @collect 
 end

--- a/docs/examples/UserGuide/functions_pass_to_DB.jl
+++ b/docs/examples/UserGuide/functions_pass_to_DB.jl
@@ -85,3 +85,13 @@ end
     @aside @show_query _
     @collect
 end
+
+# ## Interpolating queries
+# To use a prior, uncollected TidierDB query in other TidierDB macros, interpolate the needed query without showing or collecting it 
+ok = @chain DB.t(test_db) DB.@summarize(mean = mean(value));
+# the mean value represented in SQL from the above is 3
+@eval @chain DB.t(test_db) DB.@filter(value > $ok) DB.@collect
+
+@eval @chain DB.t(test_db) DB.@mutate(value2 =  value * $ok) DB.@collect
+
+@eval @chain DB.t(test_db) DB.@summarize(value =  mean(value)* $ok) DB.@collect

--- a/docs/examples/UserGuide/functions_pass_to_DB.jl
+++ b/docs/examples/UserGuide/functions_pass_to_DB.jl
@@ -19,7 +19,7 @@ df_mem = db_table(db, "dfm");
 num = [3]; 
 column = :id;
 @eval @chain t(df_mem) begin
-        @filter(value < $num) 
+        @filter(value in $num) 
         @select($column)
         @collect
     end
@@ -28,7 +28,7 @@ column = :id;
 # Begin by defining your function as your normally would, but before `@chain` you need to use `@eval`. For the variables to be interpolated in need to be started with `$`
 function test(vals, cols)
     @eval @chain t(df_mem) begin
-        @filter(value < $vals) 
+        @filter(value in $vals) 
         @select($cols)
         @collect
     end

--- a/docs/examples/UserGuide/functions_pass_to_DB.jl
+++ b/docs/examples/UserGuide/functions_pass_to_DB.jl
@@ -88,10 +88,19 @@ end
 
 # ## Interpolating queries
 # To use a prior, uncollected TidierDB query in other TidierDB macros, interpolate the needed query without showing or collecting it 
-ok = @chain DB.t(test_db) DB.@summarize(mean = mean(value));
+ok = @chain t(test_db) @summarize(mean = mean(value));
 # the mean value represented in SQL from the above is 3
-@eval @chain DB.t(test_db) DB.@filter(value > $ok) DB.@collect
+@eval @chain t(test_db) begin 
+    @filter( value > $ok) 
+    @collect 
+end
 
-@eval @chain DB.t(test_db) DB.@mutate(value2 =  value * $ok) DB.@collect
+@eval @chain t(test_db) begin 
+    @mutate(value2 =  value + $ok) 
+    @collect 
+end
 
-@eval @chain DB.t(test_db) DB.@summarize(value =  mean(value)* $ok) DB.@collect
+@eval @chain t(test_db) begin 
+    @summarize(value =  mean(value) * $ok) 
+    @collect 
+end

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -33,7 +33,7 @@ TidierDB.jl currently supports:
 | **Category**                     | **Supported Macros and Functions**                                                                                                                                               |
 |----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Data Manipulation**     | `@arrange`, `@group_by`, `@filter`, `@select`, `@mutate` (supports `across`), `@summarize`/`@summarise` (supports `across`), `@distinct`                                 |
-| **Joining**                  | `@left_join`, `@right_join`, `@inner_join`, `@anti_join`, `@full_join`, `@semi_join`, `@union`                                          |
+| **Joining**                  | `@left_join`, `@right_join`, `@inner_join`, `@anti_join`, `@full_join`, `@semi_join`, `@union`, `@union_all`                                          |
 | **Slice and Order**       | `@slice_min`, `@slice_max`, `@slice_sample`, `@order`, `@window_order`, `@window_frame`                                                                                                |
 | **Utility**               | `@show_query`, `@collect`, `@head`, `@count`, `show_tables`, `@create_view` , `drop_view`                                                                                                                                          |
 | **Helper Functions**             | `across`, `desc`, `if_else`, `case_when`, `n`, `starts_with`, `ends_with`, `contains`, `as_float`, `as_integer`, `as_string`, `is_missing`, `missing_if`, `replace_missing` |

--- a/ext/LibPQExt.jl
+++ b/ext/LibPQExt.jl
@@ -42,7 +42,7 @@ function TidierDB.show_tables(con::LibPQ.Connection)
 end
 
 function TidierDB.final_compute(sqlquery::SQLQuery, ::Type{<:postgres}, sql_cr_or_relace::String=nothing)
-    final_query = finalize_query(sqlquery)
+    final_query = TidierDB.finalize_query(sqlquery)
     final_query = sql_cr_or_relace * final_query
     return LibPQ.execute(sq.db, final_query)
 end

--- a/ext/MySQLExt.jl
+++ b/ext/MySQLExt.jl
@@ -51,7 +51,7 @@ function TidierDB.show_tables(conn::MySQL.Connection)
 end
 
 function TidierDB.final_compute(sqlquery::SQLQuery, ::Type{<:mysql}, sql_cr_or_relace::String=nothing)
-    final_query = finalize_query(sqlquery)
+    final_query = TidierDB.finalize_query(sqlquery)
     final_query = sql_cr_or_relace * final_query
     return DBInterface.execute(sq.db, final_query)
 end

--- a/src/TBD_macros.jl
+++ b/src/TBD_macros.jl
@@ -3,7 +3,7 @@ $docstring_select
 """
 macro select(sqlquery, exprs...)
     exprs = parse_blocks(exprs...)
-   # exprs_str = parse_interpolation2.(exprs)
+
     return quote
         exprs_str = map(expr -> isa(expr, Symbol) ? string(expr) : expr, $exprs)
         let columns = parse_tidy_db(exprs_str, $(esc(sqlquery)).metadata)
@@ -39,7 +39,7 @@ $docstring_filter
 """
 macro filter(sqlquery, conditions...)
     conditions = parse_blocks(conditions...)
-    conditions = parse_interpolation2.(conditions)
+
     return quote
         sq = $(esc(sqlquery))
         if isa(sq, SQLQuery)
@@ -121,7 +121,6 @@ desc(col::Symbol) = (col, :desc)
 $docstring_arrange
 """
 macro arrange(sqlquery, columns...)
-    columns = parse_interpolation2.(columns)
 
     # Initialize a string to hold column order specifications
     order_specs = String[]
@@ -200,7 +199,7 @@ $docstring_mutate
 """
 macro mutate(sqlquery, mutations...)
     mutations = parse_blocks(mutations...)
-    mutations = parse_interpolation2.(mutations)
+
     return quote
         sq = $(esc(sqlquery))
         if isa(sq, SQLQuery)
@@ -309,7 +308,6 @@ $docstring_group_by
 """
 macro group_by(sqlquery, columns...)
     columns = parse_blocks(columns...)
-    columns = parse_interpolation2.(columns)
 
     return quote
         columns_str = map(col -> isa(col, Symbol) ? string(col) : col, $columns)
@@ -347,7 +345,6 @@ end
 $docstring_distinct
 """
 macro distinct(sqlquery, distinct_columns...)
-    distinct_columns = parse_interpolation2.(distinct_columns)
     return quote
         sq = $(esc(sqlquery))
         if isa(sq, SQLQuery)
@@ -408,7 +405,6 @@ $docstring_summarize
 """
 macro summarize(sqlquery, expressions...)
     expressions = parse_blocks(expressions...)
-    expressions = parse_interpolation2.(expressions)
 
     return quote
         sq = $(esc(sqlquery))
@@ -471,7 +467,7 @@ $docstring_count
 """
 macro count(sqlquery, group_by_columns...)
     # Convert the group_by_columns to a string representation
-    group_by_columns = parse_interpolation2.(group_by_columns)
+
     group_by_cols_str = [string(col) for col in group_by_columns]
     group_clause = join(group_by_cols_str, ", ")
 
@@ -511,7 +507,7 @@ $docstring_rename
 """
 macro rename(sqlquery, renamings...)
     renamings = parse_blocks(renamings...)
-    renamings = parse_interpolation2.(renamings)
+
     return quote
         # Prepare the renaming rules from the macro arguments
         renamings_dict = Dict{String, String}()
@@ -713,4 +709,3 @@ $docstring_show_tables
 function show_tables(con::Union{DuckDB.DB, DuckDB.Connection})
     return DataFrame(DBInterface.execute(con, "SHOW ALL TABLES"))
 end
-

--- a/src/TidierDB.jl
+++ b/src/TidierDB.jl
@@ -172,7 +172,7 @@ function finalize_query(sqlquery::SQLQuery)
      "FROM )" => ")" ,  "SELECT SELECT " => "SELECT ", "SELECT  SELECT " => "SELECT ", "DISTINCT SELECT " => "DISTINCT ", 
      "SELECT SELECT SELECT " => "SELECT ", "PARTITION BY GROUP BY" => "PARTITION BY", "GROUP BY GROUP BY" => "GROUP BY", "HAVING HAVING" => "HAVING", 
      r"var\"(.*?)\"" => s"\1", r"\"\\\$" => "\"\$",  "WHERE \"" => "WHERE ", "WHERE \"NOT" => "WHERE NOT", "%')\"" =>"%\")", "NULL)\"" => "NULL)",
-    "NULL))\"" => "NULL))", r"(?i)INTERVAL(\d+)([a-zA-Z]+)" => s"INTERVAL \1 \2", "SELECT SUMMARIZE " =>  "SUMMARIZE "
+    "NULL))\"" => "NULL))", r"(?i)INTERVAL(\d+)([a-zA-Z]+)" => s"INTERVAL \1 \2", "SELECT SUMMARIZE " =>  "SUMMARIZE ", "\"(__(" => "(", ")__(\"" => ")"
      )
      complete_query = replace(complete_query, ", AS " => " AS ", "OR  \"" => "OR ")
     if current_sql_mode[] == postgres() || current_sql_mode[] == duckdb() || current_sql_mode[] == mysql() || current_sql_mode[] == mssql() || current_sql_mode[] == clickhouse() || current_sql_mode[] == athena() || current_sql_mode[] == gbq() || current_sql_mode[] == oracle()  || current_sql_mode[] == snowflake() || current_sql_mode[] == databricks()

--- a/src/parsing_athena.jl
+++ b/src/parsing_athena.jl
@@ -141,7 +141,7 @@ function expr_to_sql_trino(expr, sq; from_summarize::Bool)
         elseif @capture(x, missingif(column_, value_to_replace_))
                 return :(NULLIF($column, $value_to_replace))   
         elseif isa(x, Expr) && x.head == :call
-            if x.args[1] == :if_else && length(x.args) == 4
+            if x.args[1] == :if_else
                 return parse_if_else(x)
             elseif x.args[1] == :as_float && length(x.args) == 2
                 column = x.args[2]

--- a/src/parsing_clickhouse.jl
+++ b/src/parsing_clickhouse.jl
@@ -141,7 +141,7 @@ function expr_to_sql_clickhouse(expr, sq; from_summarize::Bool)
         elseif @capture(x, missingif(column_, value_to_replace_))
                 return :(NULLIF($column, $value_to_replace))   
         elseif isa(x, Expr) && x.head == :call
-            if x.args[1] == :if_else && length(x.args) == 4
+            if x.args[1] == :if_else
                 return parse_if_else(x)
             elseif x.args[1] == :as_float && length(x.args) == 2
                 column = x.args[2]

--- a/src/parsing_clickhouse.jl
+++ b/src/parsing_clickhouse.jl
@@ -168,6 +168,8 @@ function expr_to_sql_clickhouse(expr, sq; from_summarize::Bool)
         elseif isa(x, Expr) && x.head == :call && x.args[1] == :n && length(x.args) == 1
             return "COUNT(*)"
             end
+        elseif isa(x, SQLQuery)
+            return "(__(" * finalize_query(x) * ")__("
         end
         return x
     end

--- a/src/parsing_duckdb.jl
+++ b/src/parsing_duckdb.jl
@@ -144,13 +144,13 @@ function expr_to_sql_duckdb(expr, sq; from_summarize::Bool)
                 return parse_if_else(x)
             elseif x.args[1] == :as_float && length(x.args) == 2
                 column = x.args[2]
-                return Expr(:call, Symbol("CAST"), column, Symbol("AS DECIMAL"))
+                return Expr(:call, Symbol("TRY_CAST"), column, Symbol("AS DECIMAL"))
             elseif x.args[1] == :as_integer && length(x.args) == 2
                 column = x.args[2]
-                return Expr(:call, Symbol("CAST"), column, Symbol("AS INT"))
+                return Expr(:call, Symbol("TRY_CAST"), column, Symbol("AS INT"))
             elseif x.args[1] == :as_string && length(x.args) == 2
                 column = x.args[2]
-                return Expr(:call, Symbol("CAST"), column, Symbol("AS STRING"))
+                return Expr(:call, Symbol("TRY_CAST"), column, Symbol("AS STRING"))
             elseif x.args[1] == :case_when
                 return parse_case_when(x)
         elseif isa(x, Expr) && x.head == :call && x.args[1] == :!  && x.args[1] != :!= && length(x.args) == 2

--- a/src/parsing_duckdb.jl
+++ b/src/parsing_duckdb.jl
@@ -140,7 +140,7 @@ function expr_to_sql_duckdb(expr, sq; from_summarize::Bool)
         elseif @capture(x, missingif(column_, value_to_replace_))
                 return :(NULLIF($column, $value_to_replace))   
         elseif isa(x, Expr) && x.head == :call
-            if x.args[1] == :if_else && length(x.args) == 4
+            if x.args[1] == :if_else
                 return parse_if_else(x)
             elseif x.args[1] == :as_float && length(x.args) == 2
                 column = x.args[2]

--- a/src/parsing_duckdb.jl
+++ b/src/parsing_duckdb.jl
@@ -1,4 +1,7 @@
 function expr_to_sql_duckdb(expr, sq; from_summarize::Bool)
+    if isa(expr, SQLQuery)
+        return "(" * finalize_query(expr) * ")"
+    end
     expr = exc_capture_bug(expr, names_to_modify)
     MacroTools.postwalk(expr) do x
         # Handle basic arithmetic and functions
@@ -167,6 +170,8 @@ function expr_to_sql_duckdb(expr, sq; from_summarize::Bool)
         elseif isa(x, Expr) && x.head == :call && x.args[1] == :n && length(x.args) == 1
             return "COUNT(*)"
             end
+       elseif isa(x, SQLQuery)
+            return "(__(" * finalize_query(x) * ")__("
         end
         return x
     end

--- a/src/parsing_gbq.jl
+++ b/src/parsing_gbq.jl
@@ -168,6 +168,8 @@ function expr_to_sql_gbq(expr, sq; from_summarize::Bool)
         elseif isa(x, Expr) && x.head == :call && x.args[1] == :n && length(x.args) == 1
             return "COUNT(*)"
             end
+        elseif isa(x, SQLQuery)
+            return "(__(" * finalize_query(x) * ")__("
         end
         return x
     end

--- a/src/parsing_gbq.jl
+++ b/src/parsing_gbq.jl
@@ -141,7 +141,7 @@ function expr_to_sql_gbq(expr, sq; from_summarize::Bool)
         elseif @capture(x, missingif(column_, value_to_replace_))
                 return :(NULLIF($column, $value_to_replace))   
         elseif isa(x, Expr) && x.head == :call
-            if x.args[1] == :if_else && length(x.args) == 4
+            if x.args[1] == :if_else
                 return parse_if_else(x)
             elseif x.args[1] == :as_float && length(x.args) == 2
                 column = x.args[2]

--- a/src/parsing_mssql.jl
+++ b/src/parsing_mssql.jl
@@ -142,7 +142,7 @@ function expr_to_sql_mssql(expr, sq; from_summarize::Bool)
         elseif @capture(x, missingif(column_, value_to_replace_))
                 return :(NULLIF($column, $value_to_replace))   
         elseif isa(x, Expr) && x.head == :call
-            if x.args[1] == :if_else && length(x.args) == 4
+            if x.args[1] == :if_else
                 return parse_if_else(x)
             elseif x.args[1] == :as_float && length(x.args) == 2
                 column = x.args[2]

--- a/src/parsing_mysql.jl
+++ b/src/parsing_mysql.jl
@@ -140,7 +140,7 @@ function expr_to_sql_mysql(expr, sq; from_summarize::Bool)
         elseif @capture(x, missingif(column_, value_to_replace_))
                 return :(NULLIF($column, $value_to_replace))   
         elseif isa(x, Expr) && x.head == :call
-            if x.args[1] == :if_else && length(x.args) == 4
+            if x.args[1] == :if_else
                 return parse_if_else(x)
             elseif x.args[1] == :as_float && length(x.args) == 2
                 column = x.args[2]

--- a/src/parsing_mysql.jl
+++ b/src/parsing_mysql.jl
@@ -167,6 +167,8 @@ function expr_to_sql_mysql(expr, sq; from_summarize::Bool)
         elseif isa(x, Expr) && x.head == :call && x.args[1] == :n && length(x.args) == 1
             return "COUNT(*)"
             end
+        elseif isa(x, SQLQuery)
+            return "(__(" * finalize_query(x) * ")__("
         end
         return x
     end

--- a/src/parsing_oracle.jl
+++ b/src/parsing_oracle.jl
@@ -135,7 +135,7 @@ function expr_to_sql_oracle(expr, sq; from_summarize::Bool)
         elseif @capture(x, missingif(column_, value_to_replace_))
                 return :(NULLIF($column, $value_to_replace))   
         elseif isa(x, Expr) && x.head == :call
-            if x.args[1] == :if_else && length(x.args) == 4
+            if x.args[1] == :if_else
                 return parse_if_else(x)
             elseif x.args[1] == :as_float && length(x.args) == 2
                 column = x.args[2]

--- a/src/parsing_postgres.jl
+++ b/src/parsing_postgres.jl
@@ -139,7 +139,7 @@ function expr_to_sql_postgres(expr, sq; from_summarize::Bool)
         elseif @capture(x, missingif(column_, value_to_replace_))
                 return :(NULLIF($column, $value_to_replace))   
         elseif isa(x, Expr) && x.head == :call
-            if x.args[1] == :if_else && length(x.args) == 4
+            if x.args[1] == :if_else
                 return parse_if_else(x)
             elseif x.args[1] == :as_float && length(x.args) == 2
                 column = x.args[2]

--- a/src/parsing_postgres.jl
+++ b/src/parsing_postgres.jl
@@ -166,6 +166,8 @@ function expr_to_sql_postgres(expr, sq; from_summarize::Bool)
         elseif isa(x, Expr) && x.head == :call && x.args[1] == :n && length(x.args) == 1
             return "COUNT(*)"
             end
+        elseif isa(x, SQLQuery)
+            return "(__(" * finalize_query(x) * ")__("
         end
         return x
     end

--- a/src/parsing_snowflake.jl
+++ b/src/parsing_snowflake.jl
@@ -167,6 +167,8 @@ function expr_to_sql_snowflake(expr, sq; from_summarize::Bool)
         elseif isa(x, Expr) && x.head == :call && x.args[1] == :n && length(x.args) == 1
             return "COUNT(*)"
             end
+        elseif isa(x, SQLQuery)
+            return "(__(" * finalize_query(x) * ")__("
         end
         return x
     end

--- a/src/parsing_snowflake.jl
+++ b/src/parsing_snowflake.jl
@@ -140,7 +140,7 @@ function expr_to_sql_snowflake(expr, sq; from_summarize::Bool)
         elseif @capture(x, missingif(column_, value_to_replace_))
                 return :(NULLIF($column, $value_to_replace))   
         elseif isa(x, Expr) && x.head == :call
-            if x.args[1] == :if_else && length(x.args) == 4
+            if x.args[1] == :if_else
                 return parse_if_else(x)
             elseif x.args[1] == :as_float && length(x.args) == 2
                 column = x.args[2]

--- a/src/parsing_sqlite.jl
+++ b/src/parsing_sqlite.jl
@@ -74,7 +74,7 @@ function expr_to_sql_lite(expr, sq; from_summarize::Bool)
         elseif @capture(x, ismissing(a_))
                 return  "($(string(a)) IS NULL)"
         elseif isa(x, Expr) && x.head == :call
-            if x.args[1] == :if_else && length(x.args) == 4
+            if x.args[1] == :if_else
                 return parse_if_else(x)
             elseif x.args[1] == :as_float && length(x.args) == 2
                 column = x.args[2]

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -40,41 +40,6 @@ mutable struct SQLQuery
     end
 end
 
-mutable struct InterpolationContext
-    variables::Dict{Symbol, Any}
-    InterpolationContext() = new(Dict{Symbol, Any}())
-end
-
-# Create a global instance of the context, hidden from the module's users.
-const GLOBAL_CONTEXT = InterpolationContext()
-
-function add_interp_parameter2!(name::Symbol, value::Any)
-    GLOBAL_CONTEXT.variables[name] = value
-    
-end
-
-function add_interp_parameter!(name::Symbol, value::Any)
-    GLOBAL_CONTEXT.variables[name] = value
-    add_interp_parameter2!(name, value)
-end
-
-macro interpolate( args...)
-    exprs = Expr[]
-    for arg in args
-        if !(arg isa Expr && arg.head == :tuple)
-            throw(ArgumentError("Each argument must be a tuple"))
-        end
-        name, value = arg.args
-        quoted_name = QuoteNode(name)
-       # try
-            push!(exprs, :(esc(add_interp_parameter!(Symbol($quoted_name), $((value))))))
-       # catch e
-         #   push!(exprs, :(esc(DB.add_interp_parameter!(Symbol($quoted_name), $((value))))))
-     #   end
-    end
-    return esc(Expr(:block, exprs...))
-end
-
 function from_query(query::TidierDB.SQLQuery)
     # Custom copy method for TidierDB.CTE
     function copy(cte::TidierDB.CTE)

--- a/test/comp_tests.jl
+++ b/test/comp_tests.jl
@@ -193,28 +193,36 @@
     @testset "Mutate with Conditionals, Strings and then Filter" begin
         # mutating with if_else then filtering on missing values 
         TDF_1 = @chain test_df @mutate(new = if_else(percent > .8, missing, percent)) @arrange(percent) @filter(ismissing(new))
-        TBD_1 = @chain DB.t(test_db) DB.@mutate(new = if_else(percent > .8, missing, percent)) DB.@arrange(percent) DB.@filter(ismissing(new)) DB.@collect
+        TDB_1 = @chain DB.t(test_db) DB.@mutate(new = if_else(percent > .8, missing, percent)) DB.@arrange(percent) DB.@filter(ismissing(new)) DB.@collect
         # mutating with case_when then filtering on missing values 
         TDF_2 = @chain test_df @mutate(new = case_when(percent > .8 => "high", percent > .5 => "medium",true => missing)) @arrange(percent) @filter(ismissing(new))
-        TBD_2 = @chain DB.t(test_db) DB.@mutate(new = case_when(percent > .8, "high", percent > .5, "medium",true, missing)) DB.@arrange(percent) DB.@filter(ismissing(new)) DB.@collect
+        TDB_2 = @chain DB.t(test_db) DB.@mutate(new = case_when(percent > .8, "high", percent > .5, "medium",true, missing)) DB.@arrange(percent) DB.@filter(ismissing(new)) DB.@collect
         TDF_3 = @chain test_df @mutate(new = case_when(percent > .8 => "high", percent > .5 => "medium",true => missing)) @arrange(percent) @filter(!ismissing(new))
-        TBD_3 = @chain DB.t(test_db) DB.@mutate(new = case_when(percent > .8, "high", percent > .5, "medium",true, missing)) DB.@arrange(percent) DB.@filter(!ismissing(new)) DB.@collect
+        TDB_3 = @chain DB.t(test_db) DB.@mutate(new = case_when(percent > .8, "high", percent > .5, "medium",true, missing)) DB.@arrange(percent) DB.@filter(!ismissing(new)) DB.@collect
         TDF_4 = @chain test_df @mutate(new = case_when(percent > .8 => "high", percent > .5 => "medium",true => missing)) @arrange(percent) @filter(ismissing(new) && groups == "aa")
-        TBD_4 = @chain DB.t(test_db) DB.@mutate(new = case_when(percent > .8, "high", percent > .5, "medium",true, missing)) DB.@arrange(percent) DB.@filter(ismissing(new) && groups == "aa") DB.@collect
+        TDB_4 = @chain DB.t(test_db) DB.@mutate(new = case_when(percent > .8, "high", percent > .5, "medium",true, missing)) DB.@arrange(percent) DB.@filter(ismissing(new) && groups == "aa") DB.@collect
         TDF_5 = @chain test_df @mutate(new = case_when(percent > .8 => "high", percent > .5 => "medium",true => missing)) @arrange(percent) @filter(!ismissing(new) && groups == "aa")
-        TBD_5 = @chain DB.t(test_db) DB.@mutate(new = case_when(percent > .8, "high", percent > .5, "medium",true, missing)) DB.@arrange(percent) DB.@filter(!ismissing(new) && groups == "aa") DB.@collect
+        TDB_5 = @chain DB.t(test_db) DB.@mutate(new = case_when(percent > .8, "high", percent > .5, "medium",true, missing)) DB.@arrange(percent) DB.@filter(!ismissing(new) && groups == "aa") DB.@collect
         # using case when with str_detect
         TDF_6 = @chain test_df @mutate(new = case_when(str_detect(id, "F") => "has F", str_detect(id, "C") => "has C", true => missing)) @arrange(percent) @filter(!ismissing(new))
-        TBD_6 = @chain DB.t(test_db) DB.@mutate(new = case_when(str_detect(id, "F"), "has F", str_detect(id, "C"), "has C", true, missing)) DB.@arrange(percent) DB.@filter(!ismissing(new)) DB.@collect
+        TDB_6 = @chain DB.t(test_db) DB.@mutate(new = case_when(str_detect(id, "F"), "has F", str_detect(id, "C"), "has C", true, missing)) DB.@arrange(percent) DB.@filter(!ismissing(new)) DB.@collect
         TDF_7 = @chain test_df @mutate(new = if_else(percent > .8, 1.0, percent)) @arrange(percent) @filter(new == 1)
-        TBD_7 = @chain DB.t(test_db) DB.@mutate(new = if_else(percent > .8, 1, percent)) DB.@arrange(percent) DB.@filter(new == 1 ) DB.@collect
-        @test all(isequal.(Array(TDF_1), Array(TBD_1)))
-        @test all(isequal.(Array(TDF_2), Array(TBD_2)))
-        @test all(isequal.(Array(TDF_3), Array(TBD_3)))
-        @test all(isequal.(Array(TDF_4), Array(TBD_4)))
-        @test all(isequal.(Array(TDF_5), Array(TBD_5)))
-        @test all(isequal.(Array(TDF_6), Array(TBD_6)))
-        @test all(isequal.(Array(TDF_7), Array(TBD_7)))
+        TDB_7 = @chain DB.t(test_db) DB.@mutate(new = if_else(percent > .8, 1, percent)) DB.@arrange(percent) DB.@filter(new == 1 ) DB.@collect
+        #if else with missing values to replace
+        TDF_8 = @chain test_df @mutate(test = missing_if(value,2)) @mutate(test2 = if_else(test >3, 55, test, 43))
+        TDB_8 = @chain DB.t(test_db) DB.@mutate(test = missing_if(value,2)) DB.@mutate(test2 = if_else(test >3, 55, test, 43)) DB.@collect
+        TDF_9 = @chain test_df @mutate(test = missing_if(value,2)) @mutate(test2 = if_else(test >3, 55, test))
+        TDB_9 = @chain DB.t(test_db) DB.@mutate(test = missing_if(value,2)) DB.@mutate(test2 = if_else(test >3, 55, test)) DB.@collect
+       
+        @test all(isequal.(Array(TDF_1), Array(TDB_1)))
+        @test all(isequal.(Array(TDF_2), Array(TDB_2)))
+        @test all(isequal.(Array(TDF_3), Array(TDB_3)))
+        @test all(isequal.(Array(TDF_4), Array(TDB_4)))
+        @test all(isequal.(Array(TDF_5), Array(TDB_5)))
+        @test all(isequal.(Array(TDF_6), Array(TDB_6)))
+        @test all(isequal.(Array(TDF_7), Array(TDB_7)))
+        @test all(isequal.(Array(TDF_8), Array(TDB_8)))
+        @test all(isequal.(Array(TDF_9), Array(TDB_9)))
     end
     @testset "Count" begin
         TDF_1 = @chain test_df @count(groups)


### PR DESCRIPTION
adds  `(table1, table2, col_name)` syntax for joins 
adds 4th arg for missing values in if_else 
adds `@union_all` to bind all rows, vs `@union` which only binds distinct rows (mirrors dbplyr)