### PR TITLE
Fixes db table and copy to for df

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
 # TidierDB.jl updates
+## v0.7.0 - 2025-01-26
+- `db_table` now supports viewing a dataframe directly - `db_table(db, df, "name4db")
+- `copy_to` will copy a table to the DuckDB db, instead of creating a view
+
 ## v0.6.3 - 2025-01-20
 - Resolve issue when filtering immediately after joining
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # TidierDB.jl updates
 ## v0.7.0 - 2025-01-26
-- `db_table` now supports viewing a dataframe directly - `db_table(db, df, "name4db")
+- `db_table` now supports viewing a dataframe directly - `db_table(db, df, "name4db")`
 - `copy_to` will copy a table to the DuckDB db, instead of creating a view
 
 ## v0.6.3 - 2025-01-20

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TidierDB"
 uuid = "86993f9b-bbba-4084-97c5-ee15961ad48b"
 authors = ["Daniel Rizk <rizk.daniel.12@gmail.com> and contributors"]
-version = "0.6.3"
+version = "0.7.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/docs/examples/UserGuide/functions_pass_to_DB.jl
+++ b/docs/examples/UserGuide/functions_pass_to_DB.jl
@@ -9,8 +9,8 @@ df = DataFrame(id = [string('A' + i ÷ 26, 'A' + i % 26) for i in 0:9],
                         groups = [i % 2 == 0 ? "aa" : "bb" for i in 1:10], 
                         value = repeat(1:5, 2), 
                         percent = 0.1:0.1:1.0);
-copy_to(db, df, "dfm");
-df_mem = db_table(db, "dfm");
+
+dfv = db_table(db,  df, "dfm");
 
 # ## Interpolation
 # Variables are interpoated using `@eval` and `$`. Place `@eval` before you begin the chain or call a TidierDb macro
@@ -18,7 +18,7 @@ df_mem = db_table(db, "dfm");
 
 num = [3]; 
 column = :id;
-@eval @chain t(df_mem) begin
+@eval @chain t(dfv) begin
         @filter(value in $num) 
         @select($column)
         @collect
@@ -27,7 +27,7 @@ column = :id;
 # ## Function set up 
 # Begin by defining your function as your normally would, but before `@chain` you need to use `@eval`. For the variables to be interpolated in need to be started with `$`
 function test(vals, cols)
-    @eval @chain t(df_mem) begin
+    @eval @chain t(dfv) begin
         @filter(value in $vals) 
         @select($cols)
         @collect
@@ -45,7 +45,7 @@ test(other_vals, cols)
 
 # Defineing a new function
 function gs(groups, aggs, new_name, threshold)
-    @eval @chain t(df_mem) begin
+    @eval @chain t(dfv) begin
         @group_by($groups) 
         @summarize($new_name = mean($aggs))
         @filter($new_name > $threshold)
@@ -71,7 +71,7 @@ function moving_aggs(table, start, stop, group, order, col)
     return qry
 end;
 
-@chain t(df_mem) begin
+@chain t(dfv) begin
     moving_aggs(-2, 1, :groups, :percent, :value)
     @filter value_mean > 2.75 
     @aside @show_query _
@@ -79,7 +79,7 @@ end;
 end
 
 # Filtering before the window functions
-@chain t(df_mem) begin
+@chain t(dfv) begin
     @filter(value >=2 )
     moving_aggs(-1, 1, :groups, :percent, :value)
     @aside @show_query _
@@ -88,23 +88,23 @@ end
 
 # ## Interpolating Queries
 # To use a prior, uncollected TidierDB query in other TidierDB macros, interpolate the needed query without showing or collecting it 
-ok = @chain t(df_mem) @summarize(mean = mean(value));
+ok = @chain t(dfv) @summarize(mean = mean(value));
 # The mean value represented in SQL from the above is 3
 
 # With `@filter`
-@eval @chain t(df_mem) begin 
+@eval @chain t(dfv) begin 
     @filter( value > $ok) 
     @collect 
 end
 
 # With `@mutate`
-@eval @chain t(df_mem) begin 
+@eval @chain t(dfv) begin 
     @mutate(value2 =  value + $ok) 
     @collect 
 end
 
 # With `@summarize`
-@eval @chain t(df_mem) begin 
+@eval @chain t(dfv) begin 
     @summarize(value =  mean(value) * $ok) 
     @collect 
 end

--- a/docs/examples/UserGuide/key_differences.jl
+++ b/docs/examples/UserGuide/key_differences.jl
@@ -13,7 +13,7 @@ df = DataFrame(id = [string('A' + i ÷ 26, 'A' + i % 26) for i in 0:9],
 
 db = connect(duckdb());
 
-copy_to(db, df, "df_mem"); # copying over the data frame to an in-memory database
+dfv = db_table(db, df, "dfv"); # create a view (not a copy) of the dataframe on a in-memory database
 
 # ## Row ordering
 
@@ -28,7 +28,7 @@ copy_to(db, df, "df_mem"); # copying over the data frame to an in-memory databas
 # In TidierDB, when performing `@group_by` then `@mutate`, the table will be ungrouped after applying all of the mutations in the clause to the grouped data. To perform subsequent grouped operations, the user would have to regroup the data. This is demonstrated below.
 
 
-@chain db_table(db, :df_mem) begin
+@chain t(dfv) begin
     @group_by(groups)
     @summarize(mean_percent = mean(percent))
     @collect
@@ -36,7 +36,7 @@ copy_to(db, df, "df_mem"); # copying over the data frame to an in-memory databas
 
 # Regrouping following `@mutate`
 
-@chain db_table(db, :df_mem) begin
+@chain t(dfv) begin
     @group_by(groups)
     @mutate(max = maximum(percent), min = minimum(percent))
     @group_by(groups)
@@ -49,7 +49,7 @@ end
 # In TidierDB, after the clause is completed, the result for the new column should is separated by a comma `,`
 # in contrast to TidierData.jl, where the result for the new column is separated by a `=>` .
 
-@chain db_table(db, :df_mem) begin
+@chain t(dfv) begin
     @mutate(new_col = case_when(percent > .5, "Pass",  # in TidierData, percent > .5 => "Pass", 
                                 percent <= .5, "Try Again", # percent <= .5 => "Try Again"
                                 true, "middle"))

--- a/src/joins_sq.jl
+++ b/src/joins_sq.jl
@@ -1,6 +1,3 @@
-## Join macros are long, but all basically identical logic 
-## just change the join keyword. 
-
 function gbq_join_parse(input)
     input = string(input)
     parts = split(input, ".")
@@ -17,7 +14,8 @@ function gbq_join_parse(input)
     end
 end
 
-
+# COV_EXCL_START
+# no longer used, need to test but anticipate deleting
 function get_join_columns(db, join_table, lhs_col_str)
     if current_sql_mode[] == mssql()
         cols = get_table_metadata(db, string(join_table))
@@ -29,6 +27,8 @@ function get_join_columns(db, join_table, lhs_col_str)
         return string(gbq_join_parse(join_table)) * ".* FROM "
     end
 end
+# COV_EXCL_STOP
+
 
 function finalize_query_jq(sqlquery::SQLQuery, from_clause)
 

--- a/src/joins_sq.jl
+++ b/src/joins_sq.jl
@@ -1,5 +1,6 @@
 ## Join macros are long, but all basically identical logic 
 ## just change the join keyword. 
+
 function gbq_join_parse(input)
     input = string(input)
     parts = split(input, ".")
@@ -15,6 +16,7 @@ function gbq_join_parse(input)
         return input
     end
 end
+
 
 function get_join_columns(db, join_table, lhs_col_str)
     if current_sql_mode[] == mssql()

--- a/test/comp_tests.jl
+++ b/test/comp_tests.jl
@@ -87,7 +87,8 @@
     end
     @testset "Joins, Unions, Post Wrangle Joins" begin
         TDF_1 = @chain test_df @left_join( df2, id = id2) @arrange(id)
-        TDB_1 = @chain DB.t(test_db) DB.@left_join("df_join", id == id2) DB.@collect() @arrange(id)
+        TDB_1 = @chain DB.t(test_db) DB.@left_join("main.df_join", id == id2) DB.@collect() @arrange(id)
+        TDB_1_1 = @chain DB.t(test_db) DB.@left_join("df_join", id == id2) DB.@collect() @arrange(id)
         query = DB.@chain DB.t(join_db) DB.@filter(score > 85)
         TDF_2 = @chain test_df @left_join( @filter(df2, score > 85), id = id2) @arrange(percent)
         TDB_2 = @chain DB.t(test_db) DB.@left_join(DB.t(query), id == id2) DB.@arrange(percent) DB.@collect
@@ -126,6 +127,7 @@
         TDB_14 = @chain DB.t(test_db) DB.@full_join(DB.t(query), id == id2) DB.@mutate(score = replace_missing(score, 0)) DB.@right_join((@chain DB.t(join_db2) DB.@filter(value2 != 20)), id == id3) DB.@arrange(description) DB.@collect
 
         @test all(isequal.(Array(TDF_1), Array(TDB_1)))
+        @test all(isequal.(Array(TDF_1), Array(TDB_1_1)))
         @test all(isequal.(Array(TDF_2), Array(TDB_2)))
         @test all(isequal.(Array(TDF_3), Array(TDB_3)))
         @test all(isequal.(Array(TDF_4), Array(TDB_4)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,3 +38,5 @@ join_db2 = DB.db_table(db, df3, "df_join2");
 @testset "TidierDB to TidierData comparisons" verbose = true begin
    include("comp_tests.jl")
 end
+
+DB.DBInterface.close(db)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,12 +31,9 @@ df3 = DataFrame(id3 = [string('A' + i ÷ 26, 'A' + i % 26) for i in 0:89],
                 value2 = [10 * i for i in 1:90])
 
 db = DB.connect(DB.duckdb());
-DB.copy_to(db, test_df, "test_df");
-DB.copy_to(db, df2, "df_join");
-DB.copy_to(db, df3, "df_join2");
-test_db = DB.db_table(db, "test_df");
-join_db = DB.db_table(db, "df_join");
-join_db2 = DB.db_table(db, "df_join2");
+test_db = DB.db_table(db, test_df, "test_df");
+join_db = DB.db_table(db, df2, "df_join");
+join_db2 = DB.db_table(db, df3, "df_join2");
 
 @testset "TidierDB to TidierData comparisons" verbose = true begin
    include("comp_tests.jl")


### PR DESCRIPTION
- `db_table` now supports viewing a dataframe directly - `db_table(db, df, "name4db")`
- `copy_to` will copy a table to the DuckDB db, instead of creating a view
