### PR TITLE
Agg window fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # TidierDB.jl updates
 ## v0.7.0 - 2025-01-30
 - fixes bug when using `agg()` with window ordering and framing
+- include default support for all of the following window functions
+    - `lead`, `lag`, `dense_rank`, `nth_value`, `ntile`, `rank_dense`, `row_number`, `first_value`, `last_value`, `cume_dist`
+- add ability to change what functions are on this list to avoid the use of agg in the following manner 
+    - `push!(TidierDB.window_agg_fxns, :kurtosis);`
 
 ## v0.7.0 - 2025-01-26
 - `db_table` now supports viewing a dataframe directly - `db_table(db, df, "name4db")`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 # TidierDB.jl updates
+## v0.7.0 - 2025-01-30
+- fixes bug when using `agg()` with window ordering and framing
+
 ## v0.7.0 - 2025-01-26
 - `db_table` now supports viewing a dataframe directly - `db_table(db, df, "name4db")`
 - `copy_to` will copy a table to the DuckDB db, instead of creating a view

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TidierDB"
 uuid = "86993f9b-bbba-4084-97c5-ee15961ad48b"
 authors = ["Daniel Rizk <rizk.daniel.12@gmail.com> and contributors"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ TidierDB.jl currently supports the following top-level macros:
 | **Helper Functions**             | `across`, `desc`, `if_else`, `case_when`, `n`, `starts_with`, `ends_with`, `contains`, `as_float`, `as_integer`, `as_string`, `is_missing`, `missing_if`, `replace_missing` |
 | **TidierStrings.jl Functions** | `str_detect`, `str_replace`, `str_replace_all`, `str_remove_all`, `str_remove`                                                                                               |
 | **TidierDates.jl Functions**   | `year`, `month`, `day`, `hour`, `min`, `second`, `floor_date`, `difftime`, `mdy`, `ymd`, `dmy`                                                                                                    |
-| **Aggregate Functions**          | `mean`, `minimum`, `maximum`, `std`, `sum`, `cumsum`, and nearly all aggregate sql fxns supported
+| **Aggregate Functions**          | `mean`, `minimum`, `maximum`, `std`, `sum`, `cumsum`, and nearly all aggregate sql fxns supported |
+| **Window Functions**             | `@window_order`, `@window_frame`, or `_by`, `_order`, and `_frame` within `@mutate`                                                                                                          |
 
 `@summarize` supports any SQL aggregate function in addition to the list above. Simply write the function as written in SQL syntax and it will work.
 `@mutate` supports all builtin SQL functions as well.
@@ -159,7 +160,7 @@ end
 ```
 WITH cte_1 AS (
 SELECT *
-        FROM mtcars
+        FROM 'https://gist.githubusercontent.com/seankross/a412dfbd88b3db70b74b/raw/5f23f993cd87c283ce766e7ac6b329ee7cc2e1d1/mtcars.csv' AS mtcars 
         WHERE NOT (starts_with(model, 'M'))),
 cte_2 AS (
 SELECT cyl, AVG(mpg) AS mpg
@@ -171,9 +172,9 @@ SELECT  cyl, mpg, POWER(mpg, 2) AS mpg_squared, ROUND(mpg) AS mpg_rounded, CASE 
 cte_4 AS (
 SELECT *
         FROM cte_3
-        WHERE mpg_efficiency in ('moderate', 'efficient'))
+        WHERE mpg_efficiency in ('moderate', 'efficient'))  
 SELECT *
-        FROM cte_4
+        FROM cte_4  
         ORDER BY mpg_rounded DESC
 ```
 

--- a/docs/examples/UserGuide/key_differences.jl
+++ b/docs/examples/UserGuide/key_differences.jl
@@ -27,10 +27,9 @@ dfv = db_table(db, df, "dfv"); # create a view (not a copy) of the dataframe on 
 
 # In TidierDB, when performing `@group_by` then `@mutate`, the table will be ungrouped after applying all of the mutations in the clause to the grouped data. To perform subsequent grouped operations, the user would have to regroup the data. This is demonstrated below.
 
-
 @chain t(dfv) begin
     @group_by(groups)
-    @summarize(mean_percent = mean(percent))
+    @mutate(mean_percent = mean(percent))
     @collect
  end
 
@@ -43,6 +42,37 @@ dfv = db_table(db, df, "dfv"); # create a view (not a copy) of the dataframe on 
     @summarise(mean_percent = mean(percent))
     @collect
 end
+
+# TidierDB also supports `_by` for grouping directly within a mutate clause (a feature coming to TidierData in the the future)
+
+@chain t(dfv) begin
+    @mutate(mean_percent = mean(percent),
+        _by = groups)
+    @collect
+ end
+
+# ## Window Functions
+
+# SQL and TidierDB allow for the use of window functions. When ordering a window function, `@arrange` should not be used. Rather, `@window_order` or, preferably, `_order` in `@mutate` should be used.
+ @chain t(dfv) begin
+    @mutate(row_id = agg(row_number()), 
+        _by = groups, 
+        _order = value
+        # _frame is an available argument as well. 
+        )
+    @arrange(groups, value)
+    @aside @show_query _
+    @collect
+end 
+
+# The above query could have alternatively been written as 
+ @chain t(dfv) begin
+    @group_by groups
+    @window_order value
+    @mutate(row_id = agg(row_number()))
+    @arrange(groups, value)
+    @collect
+end 
 
 # ## Differences in `case_when()`
 

--- a/docs/examples/UserGuide/key_differences.jl
+++ b/docs/examples/UserGuide/key_differences.jl
@@ -63,8 +63,7 @@ end
 @chain t(dfv) begin
     @mutate(row_id = row_number(), 
         _by = groups, 
-        _order = value
-        # _frame is an available argument as well. 
+        _order = value # _frame is an available argument as well. 
         )
     @arrange(groups, value)
     @aside @show_query _

--- a/docs/examples/UserGuide/key_differences.jl
+++ b/docs/examples/UserGuide/key_differences.jl
@@ -53,9 +53,15 @@ end
 
 # ## Window Functions
 
-# SQL and TidierDB allow for the use of window functions. When ordering a window function, `@arrange` should not be used. Rather, `@window_order` or, preferably, `_order` in `@mutate` should be used.
- @chain t(dfv) begin
-    @mutate(row_id = agg(row_number()), 
+# SQL and TidierDB allow for the use of window functions. When ordering a window function, `@arrange` should not be used. Rather, `@window_order` or, preferably, `_order` (and `_frame`) in `@mutate` should be used.
+# The following window functions are included by default
+#     - `lead`, `lag`, `dense_rank`, `nth_value`, `ntile`, `rank_dense`, `row_number`, `first_value`, `last_value`, `cume_dist`
+# The following aggregate functions are included by default
+#     - `maximum`, `minimum`, `mean`, `std`, `sum`, `cumsum`
+# Window and aggregate functions not listed in the above can be either wrapped in `agg(kurtosis(column))` or added to an internal vector using 
+#     - `push!(TidierDB.window_agg_fxns, :kurtosis);`
+@chain t(dfv) begin
+    @mutate(row_id = row_number(), 
         _by = groups, 
         _order = value
         # _frame is an available argument as well. 
@@ -69,7 +75,7 @@ end
  @chain t(dfv) begin
     @group_by groups
     @window_order value
-    @mutate(row_id = agg(row_number()))
+    @mutate(row_id = row_number())
     @arrange(groups, value)
     @collect
 end 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,14 +32,15 @@ TidierDB.jl currently supports:
 
 | **Category**                     | **Supported Macros and Functions**                                                                                                                                               |
 |----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Data Manipulation**     | `@arrange`, `@group_by`, `@filter`, `@select`, `@mutate` (supports `across`), `@summarize`/`@summarise` (supports `across`), `@distinct`, `@relocate`                                   |
-| **Joining**                  | `@left_join`, `@right_join`, `@inner_join`, `@anti_join`, `@full_join`, `@semi_join`, `@union`, `@union_all`, `@intersect`, `@setdiff`                                         |
+| **Data Manipulation**     | `@arrange`, `@group_by`, `@filter`, `@select`, `@mutate` (supports `across`), `@summarize`/`@summarise` (supports `across`), `@distinct`, `@relocate`                                 |
+| **Joining/Setting**                  | `@left_join`, `@right_join`, `@inner_join`, `@anti_join`, `@full_join`, `@semi_join`, `@union`, `@union_all`, `@intersect`, `@setdiff`                                         |
 | **Slice and Order**       | `@slice_min`, `@slice_max`, `@slice_sample`, `@order`, `@window_order`, `@window_frame`                                                                                                |
 | **Utility**               | `@show_query`, `@collect`, `@head`, `@count`, `show_tables`, `@create_view` , `drop_view`                                                                                                                                          |
 | **Helper Functions**             | `across`, `desc`, `if_else`, `case_when`, `n`, `starts_with`, `ends_with`, `contains`, `as_float`, `as_integer`, `as_string`, `is_missing`, `missing_if`, `replace_missing` |
 | **TidierStrings.jl Functions** | `str_detect`, `str_replace`, `str_replace_all`, `str_remove_all`, `str_remove`                                                                                               |
 | **TidierDates.jl Functions**   | `year`, `month`, `day`, `hour`, `min`, `second`, `floor_date`, `difftime`, `mdy`, `ymd`, `dmy`                                                                                                    |
-| **Aggregate Functions**          | `mean`, `minimum`, `maximum`, `std`, `sum`, `cumsum`, and nearly all aggregate sql fxns supported
+| **Aggregate Functions**          | `mean`, `minimum`, `maximum`, `std`, `sum`, `cumsum`, and nearly all aggregate sql fxns supported |
+| **Window Functions**             | `@window_order`, `@window_frame`, or `_by`, `_order`, and `_frame` within `@mutate`                                                                                                          |
 
 `@summarize` supports any SQL aggregate function in addition to the list above. Simply write the function as written in SQL syntax and it will work.   
 `@mutate` supports all builtin SQL functions as well.                                                                                                 
@@ -153,7 +154,7 @@ end
 ```
 WITH cte_1 AS (
 SELECT *
-        FROM mtcars
+        FROM 'https://gist.githubusercontent.com/seankross/a412dfbd88b3db70b74b/raw/5f23f993cd87c283ce766e7ac6b329ee7cc2e1d1/mtcars.csv' AS mtcars 
         WHERE NOT (starts_with(model, 'M'))),
 cte_2 AS (
 SELECT cyl, AVG(mpg) AS mpg

--- a/src/TidierDB.jl
+++ b/src/TidierDB.jl
@@ -19,7 +19,7 @@ using GZip
  @slice_min, @slice_sample, @rename, copy_to, duckdb_open, duckdb_connect, @semi_join, @full_join, 
  @anti_join, connect, from_query, @interpolate, add_interp_parameter!, update_con,  @head, 
  clickhouse, duckdb, sqlite, mysql, mssql, postgres, athena, snowflake, gbq, oracle, databricks, SQLQuery, show_tables, 
- t, @union, @create_view, drop_view, @compute, warnings, @relocate, @union_all, @setdiff, @intersect, add_window_agg_fxn
+ t, @union, @create_view, drop_view, @compute, warnings, @relocate, @union_all, @setdiff, @intersect#, add_window_agg_fxn
 
  abstract type SQLBackend end
 
@@ -36,7 +36,7 @@ using GZip
  struct databricks <: SQLBackend end
  
  const  _warning_ = Ref(false)
- const window_agg_fxns = ["lead", "lag"]
+ const window_agg_fxns = [:lead, :lag, :dense_rank, :nth_value, :ntile, :rank_dense, :row_number, :first_value, :last_value, :cume_dist]
  current_sql_mode = Ref{SQLBackend}(duckdb())
  
  function set_sql_mode(mode::SQLBackend) current_sql_mode[] = mode end
@@ -96,14 +96,6 @@ function expr_to_sql(expr, sq; from_summarize::Bool = false)
     end
 end
 
-function add_window_agg_fxn(fxn::String)
-    if fxn in window_agg_fxns
-        println("Function '$fxn' is already in window_agg_fxns.")
-    else
-        push!(window_agg_fxns, fxn)
-        println("Function '$fxn' has been added to window_agg_fxns.")
-    end
-end
 
 """
 $docstring_warnings

--- a/src/TidierDB.jl
+++ b/src/TidierDB.jl
@@ -19,24 +19,24 @@ using GZip
  @slice_min, @slice_sample, @rename, copy_to, duckdb_open, duckdb_connect, @semi_join, @full_join, 
  @anti_join, connect, from_query, @interpolate, add_interp_parameter!, update_con,  @head, 
  clickhouse, duckdb, sqlite, mysql, mssql, postgres, athena, snowflake, gbq, oracle, databricks, SQLQuery, show_tables, 
- t, @union, @create_view, drop_view, @compute, warnings, @relocate, @union_all, @setdiff, @intersect
+ t, @union, @create_view, drop_view, @compute, warnings, @relocate, @union_all, @setdiff, @intersect, add_window_agg_fxn
 
  abstract type SQLBackend end
 
  struct clickhouse <: SQLBackend end
  struct duckdb <: SQLBackend end
- struct sqlite <: SQLBackend end
- struct mysql <: SQLBackend end
- struct mssql <: SQLBackend end
+ struct sqlite <: SQLBackend end # COV_EXCL_LINE
+ struct mysql <: SQLBackend end # COV_EXCL_LINE
+ struct mssql <: SQLBackend end # COV_EXCL_LINE
  struct postgres <: SQLBackend end
- struct athena <: SQLBackend end
+ struct athena <: SQLBackend end # COV_EXCL_LINE
  struct snowflake <: SQLBackend end
  struct gbq <: SQLBackend end
- struct oracle <: SQLBackend end
+ struct oracle <: SQLBackend end # COV_EXCL_LINE
  struct databricks <: SQLBackend end
  
  const  _warning_ = Ref(false)
-
+ const window_agg_fxns = ["lead", "lag"]
  current_sql_mode = Ref{SQLBackend}(duckdb())
  
  function set_sql_mode(mode::SQLBackend) current_sql_mode[] = mode end
@@ -96,6 +96,14 @@ function expr_to_sql(expr, sq; from_summarize::Bool = false)
     end
 end
 
+function add_window_agg_fxn(fxn::String)
+    if fxn in window_agg_fxns
+        println("Function '$fxn' is already in window_agg_fxns.")
+    else
+        push!(window_agg_fxns, fxn)
+        println("Function '$fxn' has been added to window_agg_fxns.")
+    end
+end
 
 """
 $docstring_warnings

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1865,7 +1865,7 @@ Nearly all aggregate functions from any database are supported both `@summarize`
 With `@summarize`, an aggregate functions available on a SQL backend can be used as they are in sql with the same syntax (`'` should be replaced with `"`)
 
 `@mutate` supports them as well, however, unless listed below, the function call must be wrapped with `agg()`
-       - Aggregate Functions:`maximum`, `minimum`, `mean`, `std`, `sum`, `cumsum`, 
+       - Aggregate Functions:`maximum`, `minimum`, `mean`, `std`, `sum`, `cumsum`
        - Window Functions: `lead`, `lag`, `dense_rank`, `nth_value`, `ntile`, `rank_dense`, `row_number`, `first_value`, `last_value`, `cume_dist`
 
 If a function is needed regularly, instead of wrapping it in `agg`, it can also be added to `window_agg_fxns` with `push!` as demonstrated below

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -601,7 +601,8 @@ const docstring_arrange =
 """
     @arrange(sql_query, columns...)
 
-Order SQL table rows based on specified column(s).
+Order SQL table rows based on specified column(s). Of note, `@arrange` should not be used when performing ordered window functions, 
+`@window_order`, or preferably the `_order` argument in `@mutate` should be used instead
 
 # Arguments
 - `sql_query::SQLQuery`: The SQL query to arrange

--- a/src/mutate_and_summ.jl
+++ b/src/mutate_and_summ.jl
@@ -91,7 +91,7 @@ function process_mutate_expression(expr, sq, select_expressions, cte_name)
             push!(sq.metadata, Dict("name" => col_name, "type" => "UNKNOWN", "current_selxn" => 1, "table_name" => cte_name))
         end
     else
-        throw("Unsupported expression format in @mutate: $(expr)")
+        throw("Unsupported expression format in @mutate: $(expr)") # COV_EXCL_LINE
     end
 end
 
@@ -244,7 +244,7 @@ function process_summary_expression(expr, sq, summary_str)
     
         push!(summary_str, summary_operation * " AS " * summary_column)
     else
-        throw("Unsupported expression format in @summarize: $(expr)")
+        throw("Unsupported expression format in @summarize: $(expr)") # COV_EXCL_LINE
     end
 end
 
@@ -322,7 +322,7 @@ macro summarize(sqlquery, expressions...)
             sq.is_aggregated = true        # Mark the query as aggregated
             sq.post_aggregation = true     # Indicate ready for post-aggregation operations
         else
-            error("Expected sqlquery to be an instance of SQLQuery")
+            error("Expected sqlquery to be an instance of SQLQuery") # COV_EXCL_LINE
         end
         sq
     end

--- a/src/parsing_athena.jl
+++ b/src/parsing_athena.jl
@@ -73,15 +73,7 @@ function expr_to_sql_trino(expr, sq; from_summarize::Bool)
                 str = "$(arg_str)"
                 return "$(str) $(window_clause)"
             end
-        elseif !isempty(sq.window_order) && isa(x, Expr) && x.head == :call
-            function_name = x.args[1]  # This will be `lead`
-            args = x.args[2:end]       # Capture all arguments from the second position onward
-            window_clause = construct_window_clause(sq)
-        
-            # Create the SQL string representation of the function call
-            arg_str = join(map(string, args), ", ")  # Join arguments into a string
-            str = "$(function_name)($(arg_str))"      # Construct the function call string
-            return "$(str) $(window_clause)"
+
         #stringr functions, have to use function that removes _ so capture can capture name
         elseif @capture(x, strreplaceall(str_, pattern_, replace_))
             return :(REGEXP_REPLACE($str, $pattern, $replace, 'g'))
@@ -142,25 +134,32 @@ function expr_to_sql_trino(expr, sq; from_summarize::Bool)
                 return Expr(:call, Symbol("CAST"), column, Symbol("AS STRING"))
             elseif x.args[1] == :case_when
                 return parse_case_when(x)
-        elseif isa(x, Expr) && x.head == :call && x.args[1] == :!  && x.args[1] != :!= && length(x.args) == 2
-            inner_expr = expr_to_sql_duckdb(x.args[2], sq, from_summarize = false)  # Recursively transform the inner expression
-            return string("NOT (", inner_expr, ")")
-        elseif x.args[1] == :str_detect && length(x.args) == 3
-            column, pattern = x.args[2], x.args[3]
-            if pattern isa String
-                return string(column, " LIKE \'%", pattern, "%'")
-            elseif pattern isa Expr
-                pattern_str = string(pattern)[2:end]
-                return string("REGEXP_LIKE", column, ", '", pattern_str, "')")
-            end
-        elseif isa(x, Expr) && x.head == :call && x.args[1] == :n && length(x.args) == 1
-            if from_summarize
-                return "COUNT(*)"
-            else
-                window_clause = construct_window_clause(sq)
-                return "COUNT(*) $(window_clause)"
-            end
-            end
+            elseif isa(x, Expr) && x.head == :call && x.args[1] == :!  && x.args[1] != :!= && length(x.args) == 2
+                inner_expr = expr_to_sql_duckdb(x.args[2], sq, from_summarize = false)  # Recursively transform the inner expression
+                return string("NOT (", inner_expr, ")")
+            elseif x.args[1] == :str_detect && length(x.args) == 3
+                column, pattern = x.args[2], x.args[3]
+                if pattern isa String
+                    return string(column, " LIKE \'%", pattern, "%'")
+                elseif pattern isa Expr
+                    pattern_str = string(pattern)[2:end]
+                    return string("REGEXP_LIKE", column, ", '", pattern_str, "')")
+                end
+            elseif x.args[1] == :n && length(x.args) == 1
+                return from_summarize ? "COUNT(*)" : "COUNT(*) $(construct_window_clause(sq))"
+                        elseif string(x.args[1]) in String.(window_agg_fxns)
+                    if from_summarize
+                        return x
+                    else
+                        args = x.args[2:end]       
+                        window_clause = construct_window_clause(sq)
+                        arg_str = join(map(string, args), ", ")        
+                        str_representation = "$(string(x.args[1]))($(arg_str))"  
+                        return "$(str_representation) $(window_clause)"
+                    end
+                end     
+        elseif isa(x, SQLQuery)
+            return "(__(" * finalize_query(x) * ")__("
         end
         return x
     end

--- a/src/parsing_athena.jl
+++ b/src/parsing_athena.jl
@@ -147,7 +147,7 @@ function expr_to_sql_trino(expr, sq; from_summarize::Bool)
                 end
             elseif x.args[1] == :n && length(x.args) == 1
                 return from_summarize ? "COUNT(*)" : "COUNT(*) $(construct_window_clause(sq))"
-                        elseif string(x.args[1]) in String.(window_agg_fxns)
+            elseif string(x.args[1]) in String.(window_agg_fxns)
                     if from_summarize
                         return x
                     else

--- a/src/parsing_clickhouse.jl
+++ b/src/parsing_clickhouse.jl
@@ -133,26 +133,30 @@ function expr_to_sql_clickhouse(expr, sq; from_summarize::Bool)
                 return "toString(" * string(column) * ")"
             elseif x.args[1] == :case_when
                 return parse_case_when(x)
-        elseif isa(x, Expr) && x.head == :call && x.args[1] == :!  && x.args[1] != :!= && length(x.args) == 2
-            inner_expr = expr_to_sql_clickhouse(x.args[2], sq, from_summarize = false)  # Recursively transform the inner expression
-            return string("NOT (", inner_expr, ")")
-        elseif x.args[1] == :str_detect && length(x.args) == 3
-            column, pattern = x.args[2], x.args[3]
-            if pattern isa String
-                return string(column, " LIKE \'%", pattern, "%'")
-            elseif pattern isa Expr
-                pattern_str = string(pattern)[2:end]
-                return string("match(", column, ", '", pattern_str, "')")
-            end
-        elseif x.args[1] == :n && length(x.args) == 1
-            return from_summarize ? "COUNT(*)" : "COUNT(*) $(construct_window_clause(sq))"
-        elseif string(x.args[1]) in String.(window_agg_fxns)
-                args = x.args[2:end]       
-                window_clause = construct_window_clause(sq)
-                arg_str = join(map(string, args), ", ")        
-                str_representation = "$(string(x.args[1]))($(arg_str))"  
-                return "$(str_representation) $(window_clause)"
-            end  
+            elseif isa(x, Expr) && x.head == :call && x.args[1] == :!  && x.args[1] != :!= && length(x.args) == 2
+                inner_expr = expr_to_sql_clickhouse(x.args[2], sq, from_summarize = false)  # Recursively transform the inner expression
+                return string("NOT (", inner_expr, ")")
+            elseif x.args[1] == :str_detect && length(x.args) == 3
+                column, pattern = x.args[2], x.args[3]
+                if pattern isa String
+                    return string(column, " LIKE \'%", pattern, "%'")
+                elseif pattern isa Expr
+                    pattern_str = string(pattern)[2:end]
+                    return string("match(", column, ", '", pattern_str, "')")
+                end
+            elseif x.args[1] == :n && length(x.args) == 1
+                return from_summarize ? "COUNT(*)" : "COUNT(*) $(construct_window_clause(sq))"
+            elseif string(x.args[1]) in String.(window_agg_fxns)
+                if from_summarize
+                    return x
+                else
+                    args = x.args[2:end]       
+                    window_clause = construct_window_clause(sq)
+                    arg_str = join(map(string, args), ", ")        
+                    str_representation = "$(string(x.args[1]))($(arg_str))"  
+                    return "$(str_representation) $(window_clause)"
+                end
+            end   
         elseif isa(x, SQLQuery)
             return "(__(" * finalize_query(x) * ")__("
         end

--- a/src/parsing_clickhouse.jl
+++ b/src/parsing_clickhouse.jl
@@ -73,15 +73,6 @@ function expr_to_sql_clickhouse(expr, sq; from_summarize::Bool)
                 str = "$(arg_str)"
                 return "$(str) $(window_clause)"
             end
-        elseif !isempty(sq.window_order) && isa(x, Expr) && x.head == :call
-            function_name = x.args[1]  # This will be `lead`
-            args = x.args[2:end]       # Capture all arguments from the second position onward
-            window_clause = construct_window_clause(sq)
-        
-            # Create the SQL string representation of the function call
-            arg_str = join(map(string, args), ", ")  # Join arguments into a string
-            str = "$(function_name)($(arg_str))"      # Construct the function call string
-            return "$(str) $(window_clause)"
         #stringr functions, have to use function that removes _ so capture can capture name
         elseif @capture(x, strreplaceall(str_, pattern_, replace_))
             return :(replaceRegexpAll($str, $pattern, $replace))
@@ -153,14 +144,15 @@ function expr_to_sql_clickhouse(expr, sq; from_summarize::Bool)
                 pattern_str = string(pattern)[2:end]
                 return string("match(", column, ", '", pattern_str, "')")
             end
-        elseif isa(x, Expr) && x.head == :call && x.args[1] == :n && length(x.args) == 1
-            if from_summarize
-                return "COUNT(*)"
-            else
+        elseif x.args[1] == :n && length(x.args) == 1
+            return from_summarize ? "COUNT(*)" : "COUNT(*) $(construct_window_clause(sq))"
+        elseif string(x.args[1]) in String.(window_agg_fxns)
+                args = x.args[2:end]       
                 window_clause = construct_window_clause(sq)
-                return "COUNT(*) $(window_clause)"
-            end
-            end
+                arg_str = join(map(string, args), ", ")        
+                str_representation = "$(string(x.args[1]))($(arg_str))"  
+                return "$(str_representation) $(window_clause)"
+            end  
         elseif isa(x, SQLQuery)
             return "(__(" * finalize_query(x) * ")__("
         end

--- a/src/parsing_duckdb.jl
+++ b/src/parsing_duckdb.jl
@@ -76,15 +76,7 @@ function expr_to_sql_duckdb(expr, sq; from_summarize::Bool)
                 str = "$(arg_str)"
                 return "$(str) $(window_clause)"
             end
-        elseif !isempty(sq.window_order) && isa(x, Expr) && x.head == :call
-            function_name = x.args[1]  # This will be `lead`
-            args = x.args[2:end]       # Capture all arguments from the second position onward
-            window_clause = construct_window_clause(sq)
-        
-            # Create the SQL string representation of the function call
-            arg_str = join(map(string, args), ", ")  # Join arguments into a string
-            str = "$(function_name)($(arg_str))"      # Construct the function call string
-            return "$(str) $(window_clause)"
+
         #stringr functions, have to use function that removes _ so capture can capture name
         elseif @capture(x, strreplaceall(str_, pattern_, replace_))
             return :(REGEXP_REPLACE($str, $pattern, $replace, 'g'))

--- a/src/parsing_duckdb.jl
+++ b/src/parsing_duckdb.jl
@@ -151,24 +151,29 @@ function expr_to_sql_duckdb(expr, sq; from_summarize::Bool)
                 end
             elseif x.args[1] == :n && length(x.args) == 1
                 return from_summarize ? "COUNT(*)" : "COUNT(*) $(construct_window_clause(sq))"
-            elseif string(x.args[1]) in window_agg_fxns
-                    args = x.args[2:end]       
-                    window_clause = construct_window_clause(sq)
-                    arg_str = join(map(string, args), ", ")        
-                    str_representation = "$(string(x.args[1]))($(arg_str))"  
-                    return "$(str_representation) $(window_clause)"
+            elseif string(x.args[1]) in String.(window_agg_fxns)
+                    if from_summarize
+                        return x
+                    else
+                        args = x.args[2:end]       
+                        window_clause = construct_window_clause(sq)
+                        arg_str = join(map(string, args), ", ")        
+                        str_representation = "$(string(x.args[1]))($(arg_str))"  
+                        return "$(str_representation) $(window_clause)"
+                    end
                 end    
-       elseif isa(x, SQLQuery)
+        elseif isa(x, SQLQuery)
             return "(__(" * finalize_query(x) * ")__("
         end
         return x
     end
 end
 
-# This is to get aggreagate function docstring.
+
+# This is to get aggregate function docstring.
 # COV_EXCL_START
 """
-$docstring_aggregate_functions
+$docstring_aggregate_and_window_functions
 """
 function aggregate_functions() 
 end

--- a/src/parsing_gbq.jl
+++ b/src/parsing_gbq.jl
@@ -146,7 +146,7 @@ function expr_to_sql_gbq(expr, sq; from_summarize::Bool)
                 end
             elseif x.args[1] == :n && length(x.args) == 1
                 return from_summarize ? "COUNT(*)" : "COUNT(*) $(construct_window_clause(sq))"
-                        elseif string(x.args[1]) in String.(window_agg_fxns)
+            elseif string(x.args[1]) in String.(window_agg_fxns)
                     if from_summarize
                         return x
                     else

--- a/src/parsing_gbq.jl
+++ b/src/parsing_gbq.jl
@@ -73,15 +73,6 @@ function expr_to_sql_gbq(expr, sq; from_summarize::Bool)
                 str = "$(arg_str)"
                 return "$(str) $(window_clause)"
             end
-        elseif !isempty(sq.window_order) && isa(x, Expr) && x.head == :call
-            function_name = x.args[1]  # This will be `lead`
-            args = x.args[2:end]       # Capture all arguments from the second position onward
-            window_clause = construct_window_clause(sq)
-        
-            # Create the SQL string representation of the function call
-            arg_str = join(map(string, args), ", ")  # Join arguments into a string
-            str = "$(function_name)($(arg_str))"      # Construct the function call string
-            return "$(str) $(window_clause)"
         #stringr functions, have to use function that removes _ so capture can capture name
         elseif @capture(x, strreplaceall(str_, pattern_, replace_))
             return :(REGEXP_REPLACE($str, $pattern, $replace, 'g'))
@@ -142,25 +133,30 @@ function expr_to_sql_gbq(expr, sq; from_summarize::Bool)
                 return Expr(:call, Symbol("CAST"), column, Symbol("AS STRING"))
             elseif x.args[1] == :case_when
                 return parse_case_when(x)
-        elseif isa(x, Expr) && x.head == :call && x.args[1] == :!  && x.args[1] != :!= && length(x.args) == 2
-            inner_expr = expr_to_sql_gbq(x.args[2], sq, from_summarize = false)  # Recursively transform the inner expression
-            return string("NOT (", inner_expr, ")")
-        elseif x.args[1] == :str_detect && length(x.args) == 3
-            column, pattern = x.args[2], x.args[3]
-            if pattern isa String
-                return string(column, " LIKE \'%", pattern, "%'")
-            elseif pattern isa Expr
-                pattern_str = string(pattern)[2:end]
-                return string("REGEXP_CONTAINS(", column, ", '", pattern_str, "')")
-            end
-        elseif isa(x, Expr) && x.head == :call && x.args[1] == :n && length(x.args) == 1
-            if from_summarize
-                return "COUNT(*)"
-            else
-                window_clause = construct_window_clause(sq)
-                return "COUNT(*) $(window_clause)"
-            end
-            end
+            elseif isa(x, Expr) && x.head == :call && x.args[1] == :!  && x.args[1] != :!= && length(x.args) == 2
+                inner_expr = expr_to_sql_gbq(x.args[2], sq, from_summarize = false)  # Recursively transform the inner expression
+                return string("NOT (", inner_expr, ")")
+            elseif x.args[1] == :str_detect && length(x.args) == 3
+                column, pattern = x.args[2], x.args[3]
+                if pattern isa String
+                    return string(column, " LIKE \'%", pattern, "%'")
+                elseif pattern isa Expr
+                    pattern_str = string(pattern)[2:end]
+                    return string("REGEXP_CONTAINS(", column, ", '", pattern_str, "')")
+                end
+            elseif x.args[1] == :n && length(x.args) == 1
+                return from_summarize ? "COUNT(*)" : "COUNT(*) $(construct_window_clause(sq))"
+                        elseif string(x.args[1]) in String.(window_agg_fxns)
+                    if from_summarize
+                        return x
+                    else
+                        args = x.args[2:end]       
+                        window_clause = construct_window_clause(sq)
+                        arg_str = join(map(string, args), ", ")        
+                        str_representation = "$(string(x.args[1]))($(arg_str))"  
+                        return "$(str_representation) $(window_clause)"
+                    end
+                end   
         elseif isa(x, SQLQuery)
             return "(__(" * finalize_query(x) * ")__("
         end

--- a/src/parsing_mssql.jl
+++ b/src/parsing_mssql.jl
@@ -134,7 +134,7 @@ function expr_to_sql_mssql(expr, sq; from_summarize::Bool)
                 return string(column, " LIKE \'%", pattern, "%'")
             elseif x.args[1] == :n && length(x.args) == 1
                 return from_summarize ? "COUNT(*)" : "COUNT(*) $(construct_window_clause(sq))"
-                        elseif string(x.args[1]) in String.(window_agg_fxns)
+            elseif string(x.args[1]) in String.(window_agg_fxns)
                     if from_summarize
                         return x
                     else

--- a/src/parsing_mssql.jl
+++ b/src/parsing_mssql.jl
@@ -73,15 +73,6 @@ function expr_to_sql_mssql(expr, sq; from_summarize::Bool)
                 str = "$(arg_str)"
                 return "$(str) $(window_clause)"
             end
-        elseif !isempty(sq.window_order) && isa(x, Expr) && x.head == :call
-            function_name = x.args[1]  # This will be `lead`
-            args = x.args[2:end]       # Capture all arguments from the second position onward
-            window_clause = construct_window_clause(sq)
-        
-            # Create the SQL string representation of the function call
-            arg_str = join(map(string, args), ", ")  # Join arguments into a string
-            str = "$(function_name)($(arg_str))"      # Construct the function call string
-            return "$(str) $(window_clause)"
         #stringr functions, have to use function that removes _ so capture can capture name
         elseif @capture(x, strreplaceall(str_, pattern_, replace_))
             return :(REPLACE($str, $pattern, $replace))
@@ -135,20 +126,27 @@ function expr_to_sql_mssql(expr, sq; from_summarize::Bool)
                 return Expr(:call, Symbol("CAST"), column, Symbol("AS STRING"))
             elseif x.args[1] == :case_when
                 return parse_case_when(x)
-        elseif isa(x, Expr) && x.head == :call && x.args[1] == :!  && x.args[1] != :!= && length(x.args) == 2
-            inner_expr = expr_to_sql_mssql(x.args[2], sq, from_summarize = false)  # Recursively transform the inner expression
-            return string("NOT (", inner_expr, ")")
-        elseif x.args[1] == :str_detect && length(x.args) == 3
-            column, pattern = x.args[2], x.args[3]
-            return string(column, " LIKE \'%", pattern, "%'")
-        elseif isa(x, Expr) && x.head == :call && x.args[1] == :n && length(x.args) == 1
-            if from_summarize
-                return "COUNT(*)"
-            else
-                window_clause = construct_window_clause(sq)
-                return "COUNT(*) $(window_clause)"
-            end
-            end
+            elseif isa(x, Expr) && x.head == :call && x.args[1] == :!  && x.args[1] != :!= && length(x.args) == 2
+                inner_expr = expr_to_sql_mssql(x.args[2], sq, from_summarize = false)  # Recursively transform the inner expression
+                return string("NOT (", inner_expr, ")")
+            elseif x.args[1] == :str_detect && length(x.args) == 3
+                column, pattern = x.args[2], x.args[3]
+                return string(column, " LIKE \'%", pattern, "%'")
+            elseif x.args[1] == :n && length(x.args) == 1
+                return from_summarize ? "COUNT(*)" : "COUNT(*) $(construct_window_clause(sq))"
+                        elseif string(x.args[1]) in String.(window_agg_fxns)
+                    if from_summarize
+                        return x
+                    else
+                        args = x.args[2:end]       
+                        window_clause = construct_window_clause(sq)
+                        arg_str = join(map(string, args), ", ")        
+                        str_representation = "$(string(x.args[1]))($(arg_str))"  
+                        return "$(str_representation) $(window_clause)"
+                    end
+                end     
+       elseif isa(x, SQLQuery)
+            return "(__(" * finalize_query(x) * ")__("
         end
         return x
     end

--- a/src/parsing_mysql.jl
+++ b/src/parsing_mysql.jl
@@ -73,15 +73,7 @@ function expr_to_sql_mysql(expr, sq; from_summarize::Bool)
                 str = "$(arg_str)"
                 return "$(str) $(window_clause)"
             end
-        elseif !isempty(sq.window_order) && isa(x, Expr) && x.head == :call
-            function_name = x.args[1]  # This will be `lead`
-            args = x.args[2:end]       # Capture all arguments from the second position onward
-            window_clause = construct_window_clause(sq)
-        
-            # Create the SQL string representation of the function call
-            arg_str = join(map(string, args), ", ")  # Join arguments into a string
-            str = "$(function_name)($(arg_str))"      # Construct the function call string
-            return "$(str) $(window_clause)"
+
         #stringr functions, have to use function that removes _ so capture can capture name
         elseif @capture(x, strreplaceall(str_, pattern_, replace_))
             return :(REGEXP_REPLACE($str, $pattern, $replace))
@@ -141,28 +133,33 @@ function expr_to_sql_mysql(expr, sq; from_summarize::Bool)
                 return Expr(:call, Symbol("CAST"), column, Symbol("AS STRING"))
             elseif x.args[1] == :case_when
                 return parse_case_when(x)
-        elseif isa(x, Expr) && x.head == :call && x.args[1] == :!  && x.args[1] != :!= && length(x.args) == 2
-            inner_expr = expr_to_sql_mysql(x.args[2], sq, from_summarize = false)  # Recursively transform the inner expression
-            return string("NOT (", inner_expr, ")")
-        elseif x.args[1] == :str_detect && length(x.args) == 3
-            column, pattern = x.args[2], x.args[3]
-            if pattern isa String
-                return string(column, " LIKE \'%", pattern, "%'")
-            elseif pattern isa Expr
-                pattern_str = string(pattern)[2:end]
-                return string("REGEXP_LIKE(", column, ", '", pattern_str, "')")
-            end
-        elseif isa(x, Expr) && x.head == :call && x.args[1] == :n && length(x.args) == 1
-            return "COUNT(*)"
-            end
-        elseif isa(x, Expr) && x.head == :call && x.args[1] == :n && length(x.args) == 1
-            if from_summarize
-                return "COUNT(*)"
-            else
-                window_clause = construct_window_clause(sq)
-                return "COUNT(*) $(window_clause)"
-            end
-            end
+            elseif isa(x, Expr) && x.head == :call && x.args[1] == :!  && x.args[1] != :!= && length(x.args) == 2
+                inner_expr = expr_to_sql_mysql(x.args[2], sq, from_summarize = false)  # Recursively transform the inner expression
+                return string("NOT (", inner_expr, ")")
+            elseif x.args[1] == :str_detect && length(x.args) == 3
+                column, pattern = x.args[2], x.args[3]
+                if pattern isa String
+                    return string(column, " LIKE \'%", pattern, "%'")
+                elseif pattern isa Expr
+                    pattern_str = string(pattern)[2:end]
+                    return string("REGEXP_LIKE(", column, ", '", pattern_str, "')")
+                end
+            elseif x.args[1] == :n && length(x.args) == 1
+                return from_summarize ? "COUNT(*)" : "COUNT(*) $(construct_window_clause(sq))"
+                        elseif string(x.args[1]) in String.(window_agg_fxns)
+                    if from_summarize
+                        return x
+                    else
+                        args = x.args[2:end]       
+                        window_clause = construct_window_clause(sq)
+                        arg_str = join(map(string, args), ", ")        
+                        str_representation = "$(string(x.args[1]))($(arg_str))"  
+                        return "$(str_representation) $(window_clause)"
+                    end
+                end     
+       elseif isa(x, SQLQuery)
+            return "(__(" * finalize_query(x) * ")__("
+        end
         return x
     end
 end

--- a/src/parsing_mysql.jl
+++ b/src/parsing_mysql.jl
@@ -146,7 +146,7 @@ function expr_to_sql_mysql(expr, sq; from_summarize::Bool)
                 end
             elseif x.args[1] == :n && length(x.args) == 1
                 return from_summarize ? "COUNT(*)" : "COUNT(*) $(construct_window_clause(sq))"
-                        elseif string(x.args[1]) in String.(window_agg_fxns)
+            elseif string(x.args[1]) in String.(window_agg_fxns)
                     if from_summarize
                         return x
                     else

--- a/src/parsing_oracle.jl
+++ b/src/parsing_oracle.jl
@@ -73,15 +73,6 @@ function expr_to_sql_oracle(expr, sq; from_summarize::Bool)
                 str = "$(arg_str)"
                 return "$(str) $(window_clause)"
             end
-        elseif !isempty(sq.window_order) && isa(x, Expr) && x.head == :call
-            function_name = x.args[1]  # This will be `lead`
-            args = x.args[2:end]       # Capture all arguments from the second position onward
-            window_clause = construct_window_clause(sq)
-        
-            # Create the SQL string representation of the function call
-            arg_str = join(map(string, args), ", ")  # Join arguments into a string
-            str = "$(function_name)($(arg_str))"      # Construct the function call string
-            return "$(str) $(window_clause)"
         #stringr functions, have to use function that removes _ so capture can capture name
         elseif @capture(x, strreplaceall(str_, pattern_, replace_))
             return :(REPLACE($str, $pattern, $replace))
@@ -128,26 +119,33 @@ function expr_to_sql_oracle(expr, sq; from_summarize::Bool)
                 return Expr(:call, Symbol("CAST"), column, Symbol("AS STRING"))
             elseif x.args[1] == :case_when
                 return parse_case_when(x)
-        elseif isa(x, Expr) && x.head == :call && x.args[1] == :!  && x.args[1] != :!= && length(x.args) == 2
-            inner_expr = expr_to_sql_oracle(x.args[2], sq, from_summarize = false)  # Recursively transform the inner expression
-            return string("NOT (", inner_expr, ")")
-        elseif x.args[1] == :str_detect && length(x.args) == 3
-            column, pattern = x.args[2], x.args[3]
-            if pattern isa String
-                return string(column, " LIKE \'%", pattern, "%'")
-            elseif pattern isa Expr
-                pattern_str = string(pattern)[2:end]
-                return string("REGEXP_LIKE", column, ", '", pattern_str, "')")
-            end
-        elseif isa(x, Expr) && x.head == :call && x.args[1] == :n && length(x.args) == 1
-            if from_summarize
-                return "COUNT(*)"
-            else
-                window_clause = construct_window_clause(sq)
-                return "COUNT(*) $(window_clause)"
-            end
-            end
-        end
+            elseif isa(x, Expr) && x.head == :call && x.args[1] == :!  && x.args[1] != :!= && length(x.args) == 2
+                inner_expr = expr_to_sql_oracle(x.args[2], sq, from_summarize = false)  # Recursively transform the inner expression
+                return string("NOT (", inner_expr, ")")
+            elseif x.args[1] == :str_detect && length(x.args) == 3
+                column, pattern = x.args[2], x.args[3]
+                if pattern isa String
+                    return string(column, " LIKE \'%", pattern, "%'")
+                elseif pattern isa Expr
+                    pattern_str = string(pattern)[2:end]
+                    return string("REGEXP_LIKE", column, ", '", pattern_str, "')")
+                end
+            elseif x.args[1] == :n && length(x.args) == 1
+                return from_summarize ? "COUNT(*)" : "COUNT(*) $(construct_window_clause(sq))"
+                        elseif string(x.args[1]) in String.(window_agg_fxns)
+                    if from_summarize
+                        return x
+                    else
+                        args = x.args[2:end]       
+                        window_clause = construct_window_clause(sq)
+                        arg_str = join(map(string, args), ", ")        
+                        str_representation = "$(string(x.args[1]))($(arg_str))"  
+                        return "$(str_representation) $(window_clause)"
+                    end
+                end     
+            elseif isa(x, SQLQuery)
+                    return "(__(" * finalize_query(x) * ")__("
+                end
         return x
     end
 end

--- a/src/parsing_oracle.jl
+++ b/src/parsing_oracle.jl
@@ -132,7 +132,7 @@ function expr_to_sql_oracle(expr, sq; from_summarize::Bool)
                 end
             elseif x.args[1] == :n && length(x.args) == 1
                 return from_summarize ? "COUNT(*)" : "COUNT(*) $(construct_window_clause(sq))"
-                        elseif string(x.args[1]) in String.(window_agg_fxns)
+            elseif string(x.args[1]) in String.(window_agg_fxns)
                     if from_summarize
                         return x
                     else

--- a/src/parsing_postgres.jl
+++ b/src/parsing_postgres.jl
@@ -73,15 +73,6 @@ function expr_to_sql_postgres(expr, sq; from_summarize::Bool)
                 str = "$(arg_str)"
                 return "$(str) $(window_clause)"
             end
-        elseif !isempty(sq.window_order) && isa(x, Expr) && x.head == :call
-            function_name = x.args[1]  # This will be `lead`
-            args = x.args[2:end]       # Capture all arguments from the second position onward
-            window_clause = construct_window_clause(sq)
-        
-            # Create the SQL string representation of the function call
-            arg_str = join(map(string, args), ", ")  # Join arguments into a string
-            str = "$(function_name)($(arg_str))"      # Construct the function call string
-            return "$(str) $(window_clause)"
         #stringr functions, have to use function that removes _ so capture can capture name
         elseif @capture(x, strreplaceall(str_, pattern_, replace_))
             return :(REGEXP_REPLACE($str, $pattern, $replace, 'g'))
@@ -140,25 +131,30 @@ function expr_to_sql_postgres(expr, sq; from_summarize::Bool)
                 return Expr(:call, Symbol("CAST"), column, Symbol("AS STRING"))
             elseif x.args[1] == :case_when
                 return parse_case_when(x)
-        elseif isa(x, Expr) && x.head == :call && x.args[1] == :!  && x.args[1] != :!= && length(x.args) == 2
-            inner_expr = expr_to_sql_postgres(x.args[2], sq, from_summarize = false)  # Recursively transform the inner expression
-            return string("NOT (", inner_expr, ")")
-        elseif x.args[1] == :str_detect && length(x.args) == 3
-            column, pattern = x.args[2], x.args[3]
-            if pattern isa String
-                return string(column, " LIKE \'%", pattern, "%'")
-            elseif pattern isa Expr
-                pattern_str = string(pattern)[2:end]
-                return string("regexp_matches(", column, ", '", pattern_str, "')")
-            end
-        elseif isa(x, Expr) && x.head == :call && x.args[1] == :n && length(x.args) == 1
-            if from_summarize
-                return "COUNT(*)"
-            else
-                window_clause = construct_window_clause(sq)
-                return "COUNT(*) $(window_clause)"
-            end
-            end
+            elseif isa(x, Expr) && x.head == :call && x.args[1] == :!  && x.args[1] != :!= && length(x.args) == 2
+                inner_expr = expr_to_sql_postgres(x.args[2], sq, from_summarize = false)  # Recursively transform the inner expression
+                return string("NOT (", inner_expr, ")")
+            elseif x.args[1] == :str_detect && length(x.args) == 3
+                column, pattern = x.args[2], x.args[3]
+                if pattern isa String
+                    return string(column, " LIKE \'%", pattern, "%'")
+                elseif pattern isa Expr
+                    pattern_str = string(pattern)[2:end]
+                    return string("regexp_matches(", column, ", '", pattern_str, "')")
+                end
+            elseif x.args[1] == :n && length(x.args) == 1
+                return from_summarize ? "COUNT(*)" : "COUNT(*) $(construct_window_clause(sq))"
+                        elseif string(x.args[1]) in String.(window_agg_fxns)
+                    if from_summarize
+                        return x
+                    else
+                        args = x.args[2:end]       
+                        window_clause = construct_window_clause(sq)
+                        arg_str = join(map(string, args), ", ")        
+                        str_representation = "$(string(x.args[1]))($(arg_str))"  
+                        return "$(str_representation) $(window_clause)"
+                    end
+                end     
         elseif isa(x, SQLQuery)
             return "(__(" * finalize_query(x) * ")__("
         end

--- a/src/parsing_postgres.jl
+++ b/src/parsing_postgres.jl
@@ -144,7 +144,7 @@ function expr_to_sql_postgres(expr, sq; from_summarize::Bool)
                 end
             elseif x.args[1] == :n && length(x.args) == 1
                 return from_summarize ? "COUNT(*)" : "COUNT(*) $(construct_window_clause(sq))"
-                        elseif string(x.args[1]) in String.(window_agg_fxns)
+            elseif string(x.args[1]) in String.(window_agg_fxns)
                     if from_summarize
                         return x
                     else

--- a/src/parsing_snowflake.jl
+++ b/src/parsing_snowflake.jl
@@ -74,15 +74,7 @@ function expr_to_sql_snowflake(expr, sq; from_summarize::Bool)
                 str = "$(arg_str)"
                 return "$(str) $(window_clause)"
             end
-        elseif !isempty(sq.window_order) && isa(x, Expr) && x.head == :call
-            function_name = x.args[1]  # This will be `lead`
-            args = x.args[2:end]       # Capture all arguments from the second position onward
-            window_clause = construct_window_clause(sq)
-        
-            # Create the SQL string representation of the function call
-            arg_str = join(map(string, args), ", ")  # Join arguments into a string
-            str = "$(function_name)($(arg_str))"      # Construct the function call string
-            return "$(str) $(window_clause)"
+
         #stringr functions, have to use function that removes _ so capture can capture name
         elseif @capture(x, strreplaceall(str_, pattern_, replace_))
             return :(REGEXP_REPLACE($str, $pattern, $replace, 'g'))
@@ -141,28 +133,33 @@ function expr_to_sql_snowflake(expr, sq; from_summarize::Bool)
                 return Expr(:call, Symbol("CAST"), column, Symbol("AS STRING"))
             elseif x.args[1] == :case_when
                 return parse_case_when(x)
-        elseif isa(x, Expr) && x.head == :call && x.args[1] == :!  && x.args[1] != :!= && length(x.args) == 2
-            inner_expr = expr_to_sql_snowflake(x.args[2], sq, from_summarize = false)  # Recursively transform the inner expression
-            return string("NOT (", inner_expr, ")")
-        elseif x.args[1] == :str_detect && length(x.args) == 3
-            column, pattern = x.args[2], x.args[3]
-            if pattern isa String
-                return string(column, " LIKE \'%", pattern, "%'")
-            elseif pattern isa Expr
-                pattern_str = string(pattern)[2:end]
-                return string("REGEXP_LIKE", column, ", '", pattern_str, "')")
+            elseif isa(x, Expr) && x.head == :call && x.args[1] == :!  && x.args[1] != :!= && length(x.args) == 2
+                inner_expr = expr_to_sql_snowflake(x.args[2], sq, from_summarize = false)  # Recursively transform the inner expression
+                return string("NOT (", inner_expr, ")")
+            elseif x.args[1] == :str_detect && length(x.args) == 3
+                column, pattern = x.args[2], x.args[3]
+                if pattern isa String
+                    return string(column, " LIKE \'%", pattern, "%'")
+                elseif pattern isa Expr
+                    pattern_str = string(pattern)[2:end]
+                    return string("REGEXP_LIKE", column, ", '", pattern_str, "')")
+                end
+            elseif x.args[1] == :n && length(x.args) == 1
+                return from_summarize ? "COUNT(*)" : "COUNT(*) $(construct_window_clause(sq))"
+                        elseif string(x.args[1]) in String.(window_agg_fxns)
+                    if from_summarize
+                        return x
+                    else
+                        args = x.args[2:end]       
+                        window_clause = construct_window_clause(sq)
+                        arg_str = join(map(string, args), ", ")        
+                        str_representation = "$(string(x.args[1]))($(arg_str))"  
+                        return "$(str_representation) $(window_clause)"
+                    end
+                end     
+            elseif isa(x, SQLQuery)
+                return "(__(" * finalize_query(x) * ")__("
             end
-        elseif isa(x, Expr) && x.head == :call && x.args[1] == :n && length(x.args) == 1
-            if from_summarize
-                return "COUNT(*)"
-            else
-                window_clause = construct_window_clause(sq)
-                return "COUNT(*) $(window_clause)"
-            end
-            end
-        elseif isa(x, SQLQuery)
-            return "(__(" * finalize_query(x) * ")__("
-        end
         return x
     end
 end

--- a/src/parsing_snowflake.jl
+++ b/src/parsing_snowflake.jl
@@ -157,9 +157,9 @@ function expr_to_sql_snowflake(expr, sq; from_summarize::Bool)
                         return "$(str_representation) $(window_clause)"
                     end
                 end     
-            elseif isa(x, SQLQuery)
-                return "(__(" * finalize_query(x) * ")__("
-            end
+        elseif isa(x, SQLQuery)
+            return "(__(" * finalize_query(x) * ")__("
+        end
         return x
     end
 end

--- a/src/slices_sq.jl
+++ b/src/slices_sq.jl
@@ -64,7 +64,7 @@ macro slice_min(sqlquery, column, n=1)
             # Update the FROM clause to reference the new filter CTE
             sq.from = filter_cte_name
         else
-            error("Expected sqlquery to be an instance of SQLQuery")
+            error("Expected sqlquery to be an instance of SQLQuery") # COV_EXCL_LINE
         end
         sq
     end
@@ -138,7 +138,7 @@ macro slice_max(sqlquery, column, n=1)
             # Update the FROM clause to reference the new filter CTE
             sq.from = filter_cte_name
         else
-            error("Expected sqlquery to be an instance of SQLQuery")
+            error("Expected sqlquery to be an instance of SQLQuery") # COV_EXCL_LINE
         end
         sq
     end
@@ -202,7 +202,7 @@ macro slice_sample(sqlquery, n=1)
             # Reset sq.select to select everything from the final CTE
             sq.select = "*"
         else
-            error("Expected sqlquery to be an instance of SQLQuery")
+            error("Expected sqlquery to be an instance of SQLQuery") # COV_EXCL_LINE
         end
         sq
     end

--- a/src/windows.jl
+++ b/src/windows.jl
@@ -45,7 +45,7 @@ macro window_order(sqlquery, order_by_expr...)
                 sq.from = cte_name
             end
         else
-            error("Expected sqlquery to be an instance of SQLQuery")
+            error("Expected sqlquery to be an instance of SQLQuery") # COV_EXCL_LINE
         end
         sq
     end
@@ -71,11 +71,11 @@ macro window_frame(sqlquery, args...)
             elseif arg_name == :to
                 frame_to_expr = arg_value
             else
-                error("Unknown keyword argument: $(arg_name)")
+                error("Unknown keyword argument: $(arg_name)") # COV_EXCL_LINE
             end
         elseif isa(arg, Expr) && arg.head == :tuple
             if length(arg.args) != 2
-                error("`_frame` must be a tuple with exactly two elements: (_frame = (from, to))")
+                error("`_frame` must be a tuple with exactly two elements: (_frame = (from, to))") # COV_EXCL_LINE
             end
             frame_from_expr = arg.args[1]
             frame_to_expr = arg.args[2]
@@ -86,7 +86,7 @@ macro window_frame(sqlquery, args...)
             elseif frame_to_expr === nothing
                 frame_to_expr = arg
             else
-                error("Too many positional arguments")
+                error("Too many positional arguments") # COV_EXCL_LINE
             end
         end
     end
@@ -169,7 +169,7 @@ macro window_frame(sqlquery, args...)
             # Update the windowFrame field of the SQLQuery instance
             sq.windowFrame = frame_clause
         else
-            error("Expected sqlquery to be an instance of SQLQuery")
+            error("Expected sqlquery to be an instance of SQLQuery") # COV_EXCL_LINE
         end
         sq
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,4 +39,4 @@ join_db2 = DB.db_table(db, df3, "df_join2");
    include("comp_tests.jl")
 end
 
-DB.DBInterface.close(db)
+#DB.DBInterface.close(db)


### PR DESCRIPTION
Addresses #102
- fixes bug when using `agg()` with window ordering and framing
- include default support for all of the following window functions
    - `lead`, `lag`, `dense_rank`, `nth_value`, `ntile`, `rank_dense`, `row_number`, `first_value`, `last_value`, `cume_dist`
- add ability to change what functions are on this list to avoid the use of agg in the following manner 
    - `push!(TidierDB.window_agg_fxns, :kurtosis);`
- adds docstring for aggregate and window functions for improved documentation 