### PR TITLE
add google sheet support to `db_table`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,11 @@
     - `push!(TidierDB.window_agg_fxns, :kurtosis);`
 - fixes edge case query construction issues with `@mutate`,`@filter`,`@*_join`
 - fix edge case with `@select` call after group_by -> summarize
-
+- add Google Sheet support 
+```
+ghseet_connect(db)
+DB.db_table(db, "https://docs.google.com/spreadsheets/d/rest/of/link")
+```
 ## v0.7.0 - 2025-01-26
 - `db_table` now supports viewing a dataframe directly - `db_table(db, df, "name4db")`
 - `copy_to` will copy a table to the DuckDB db, instead of creating a view

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ TidierDB.jl currently supports the following top-level macros:
 `@summarize` supports any SQL aggregate function in addition to the list above. Simply write the function as written in SQL syntax and it will work.
 `@mutate` supports all builtin SQL functions as well.
 
-When using the DuckDB backend, if `db_table` recieves a file path (`.parquet`, `.json`, `.csv`, `iceberg` or `delta`), it does not copy it into memory. This allows for queries on files too big for memory. `db_table` also supports S3 bucket locations via DuckDB.
+When using the DuckDB backend, if `db_table` recieves a file path (`.parquet`, `.json`, `.csv`, `iceberg` or `delta`), it does not copy it into memory. This allows for queries on files too big for memory. `db_table` also supports S3 bucket locations and Google Sheets via DuckDB.
 
 ## What is the recommended way to use TidierDB?
 

--- a/docs/examples/UserGuide/getting_started.jl
+++ b/docs/examples/UserGuide/getting_started.jl
@@ -40,6 +40,7 @@
 # - Athena: `using AWS`
 # - Oracle: `using ODBC` 
 # - Google BigQuery: `using GoogleCloud`
+# - Google Sheets via DuckDB: run the following with your db `ghseet_connect(db)`, copy key and paste back in terminal. Then paste the entire google sheets link as your table name in `db_table`
 
 # ## `db_table`
 # What does `db_table` do? 

--- a/docs/examples/UserGuide/misc_tips.jl
+++ b/docs/examples/UserGuide/misc_tips.jl
@@ -28,6 +28,6 @@ sqc(qry) = @chain t(qry) begin
 @chain t(dfv) @summarize() sqc()
 
 # ## Color Printing
-# Queries print with some code words in color to the REPL. To turn off this feature run the one of the following.
+# Queries print with some code words in color to the REPL. To turn off this feature, run one of the following.
 #   - `TidierDB.color[] = false`
-#   - `DB.color = false`
+#   - `DB.color[] = false`

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -46,7 +46,7 @@ TidierDB.jl currently supports:
 `@mutate` supports all builtin SQL functions as well.                                                                                                 
 
 
-When using the DuckDB backend, if `db_table` recieves a file path ( `.parquet`, `.json`, `.csv`, `iceberg` or `delta`), it does not copy it into memory. This allows for queries on files too big for memory. `db_table` also supports S3 bucket locations via DuckDB.
+When using the DuckDB backend, if `db_table` recieves a file path ( `.parquet`, `.json`, `.csv`, `iceberg` or `delta`), it does not copy it into memory. This allows for queries on files too big for memory. `db_table` also supports S3 bucket locations and Google Sheets via DuckDB.
 
 
 ## What is the recommended way to use TidierDB?

--- a/src/TidierDB.jl
+++ b/src/TidierDB.jl
@@ -20,7 +20,7 @@ using Crayons
  @slice_min, @slice_sample, @rename, copy_to, duckdb_open, duckdb_connect, @semi_join, @full_join, 
  @anti_join, connect, from_query, @interpolate, add_interp_parameter!, update_con,  @head, 
  clickhouse, duckdb, sqlite, mysql, mssql, postgres, athena, snowflake, gbq, oracle, databricks, SQLQuery, show_tables, 
- t, @union, @create_view, drop_view, @compute, warnings, @relocate, @union_all, @setdiff, @intersect#, add_window_agg_fxn
+ t, @union, @create_view, drop_view, @compute, warnings, @relocate, @union_all, @setdiff, @intersect, ghseet_connect
 
  abstract type SQLBackend end
 
@@ -254,6 +254,11 @@ function db_table(db, table, athena_params::Any=nothing; iceberg::Bool=false, de
             table_name2 = "delta_scan('$table_name')"
            # println(table_name2)
             metadata = get_table_metadata(db, table_name2)
+        elseif occursin("docs.google", table_name) 
+            table_name2 = "read_gsheet('$table_name')"
+           # println(table_name2)
+            alias == "" ? alias = "gsheet" : alias = alias
+            metadata = get_table_metadata(db, table_name2, alias = alias)
         elseif startswith(table_name, "read") 
             table_name2 = "$table_name"
            metadata = get_table_metadata(db, table_name2)
@@ -486,6 +491,11 @@ end
 
 function connect(::duckdb, token::String)
      return DBInterface.connect(DuckDB.DB, token)
+end
+
+function ghseet_connect(db)
+        DuckDB.query(db, "INSTALL gsheets FROM community; LOAD gsheets;")
+        DuckDB.query(db, "CREATE SECRET (TYPE gsheet);")
 end
 # COV_EXCL_STOP
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1302,9 +1302,9 @@ const docstring_db_table =
 """
     db_table(database, table_name, athena_params, delta = false, iceberg = false, alias = "", df_name)
 
-`db_table` starts the underlying SQL query struct, adding the metadata and table. If paths are passed directly to db_table instead of a 
-name it will not copy it to memory, but rather ready directly from the file. `db_table` only supports direct file paths to a table. DataFrames 
-are read as a view. It does not support database file paths such as `dbname.duckdb` or `dbname.sqlite`. Such files must be used with `connect first`
+`db_table` starts the underlying SQL query struct, adding the metadata and table. If paths are passed directly to `db_table` instead of a 
+name it will not copy it to memory, but rather ready directly from the file. `db_table`  only supports direct file paths to a table. DataFrames 
+are read as a view. It does not support database file paths such as  `dbname.duckdb`  or  `dbname.sqlite`. Such files must be used with `connect(db, "path_to_db.duckdb")` first
 
 # Arguments
 - `database`: The Database or connection object
@@ -1315,12 +1315,13 @@ are read as a view. It does not support database file paths such as `dbname.duck
       - Iceberg
       - Delta
       - S3 tables from AWS or Google Cloud 
+      - Google Sheet spreadsheet link
      - DuckDB and ClickHouse support vectors of paths and URLs. 
      - DuckDB and ClickHouse also support use of `*` wildcards to read all files of a type in a location such as:
         - `db_table(db, "Path/to/testing_files/*.parquet")`
 - `delta`: must be true to read delta files
 - `iceberg`: must be true to read iceberg finalize_ctes
-- `alias`: optional argument when using a `*` wildcard in a file path, that allows user to determine an alias for the data being read in. If empty, it will refer to table as `data`
+- `alias`: optional argument when using a `*` wildcard in a file path, that allows user to determine an alias for the data being read in. If empty, it will refer to table as `data`.
 - `df_name` when using a DataFrame as the second argument, a third string argument must be supplied to become the name of the view.
 # Example
 ```jldoctest


### PR DESCRIPTION
support for reading gsheets in 4 lines thx to the great gsheets community extension
```
using TidierDB 
db = connect(duckdb())
ghseet_connect(db) # authenticate in browser
gsheet = DB.db_table(db, "https://docs.google.com/spreadsheets/d/rest/of/link")
```