### PR TITLE
truly remove `t`

### DIFF
--- a/src/joins_sq.jl
+++ b/src/joins_sq.jl
@@ -338,8 +338,10 @@ macro left_join(sqlquery, join_table, expr... )
 
     return quote
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
 
         jq = isa($(esc(join_table)), SQLQuery) ? t($(esc(join_table))) : $(esc(join_table)) 
 
@@ -379,8 +381,10 @@ macro right_join(sqlquery, join_table, expr... )
 
     return quote
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
         
         jq = isa($(esc(join_table)), SQLQuery) ? t($(esc(join_table))) : $(esc(join_table)) 
 
@@ -418,8 +422,10 @@ macro inner_join(sqlquery, join_table, expr... )
 
     return quote
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
 
         jq = isa($(esc(join_table)), SQLQuery) ? t($(esc(join_table))) : $(esc(join_table)) 
 
@@ -459,8 +465,10 @@ macro full_join(sqlquery, join_table, expr... )
 
     return quote
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
         
         jq = isa($(esc(join_table)), SQLQuery) ? t($(esc(join_table))) : $(esc(join_table)) 
 
@@ -499,8 +507,10 @@ macro semi_join(sqlquery, join_table, expr... )
 
     return quote
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
 
         jq = isa($(esc(join_table)), SQLQuery) ? t($(esc(join_table))) : $(esc(join_table)) 
 
@@ -540,8 +550,10 @@ macro anti_join(sqlquery, join_table, expr... )
 
     return quote
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
 
         jq = isa($(esc(join_table)), SQLQuery) ? t($(esc(join_table))) : $(esc(join_table)) 
        

--- a/src/relocate.jl
+++ b/src/relocate.jl
@@ -47,8 +47,10 @@ macro relocate(sqlquery, exprs...)
 
     return quote
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
         meta = sq.metadata
 
         selected_indices = findall(x -> x > 0, meta.current_selxn)

--- a/src/sep_unite.jl
+++ b/src/sep_unite.jl
@@ -38,8 +38,10 @@ macro separate(sqlquery, col, new_cols, sep)
 
     return quote
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
         
         sq.post_unnest ? build_cte!(sq) : nothing
         names = replace.($new_cols_names, ":" => "")
@@ -103,8 +105,10 @@ macro unite(sqlquery, new_col, col_tuple, sep, args...)
     col_names = [string(x) for x in col_tuple.args]
     return quote
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
 
         cols = filter_columns_by_expr($col_names, sq.metadata)
         unite(sq, $(QuoteNode(new_col_str)), cols, $(esc(sep)); remove=$(esc(remove_expr)))

--- a/src/slices_sq.jl
+++ b/src/slices_sq.jl
@@ -4,8 +4,10 @@ $docstring_slice_min
 macro slice_min(sqlquery, column, n=1)
     return quote
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
 
         if isa(sq, SQLQuery)
             cte_name = "cte_" * string(sq.cte_count + 1)
@@ -79,8 +81,10 @@ $docstring_slice_max
 macro slice_max(sqlquery, column, n=1)
     return quote
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
         
         if isa(sq, SQLQuery)
             cte_name = "cte_" * string(sq.cte_count + 1)
@@ -156,8 +160,10 @@ $docstring_slice_sample
 macro slice_sample(sqlquery, n=1)
     return quote
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
 
         if isa(sq, SQLQuery)
             cte_name = "cte_" * string(sq.cte_count + 1)

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -12,6 +12,7 @@ end
 
 mutable struct SQLQuery
     reuse_table::Bool
+    fresh::Bool
     select::String
     from::String
     where::String
@@ -35,11 +36,12 @@ mutable struct SQLQuery
     post_unnest::Bool
     post_mutate::Bool
     post_count::Bool
-    function SQLQuery(;reuse_table = true, select::String="", from::String="", where::String="", groupBy::String="", orderBy::String="", having::String="", 
+
+    function SQLQuery(;reuse_table = true,fresh = true, select::String="", from::String="", where::String="", groupBy::String="", orderBy::String="", having::String="", 
         window_order::String="", windowFrame::String="", is_aggregated::Bool=false, post_aggregation::Bool=false, post_join::Bool=false, metadata::DataFrame=DataFrame(), 
         distinct::Bool=false, db::Any=nothing, ctes::Vector{CTE}=Vector{CTE}(), cte_count::Int=0, athena_params::Any=nothing, limit::String="", 
-        ch_settings::String="", join_count::Int = 0, post_unnest::Bool = false, post_mutate::Bool = false,  post_count::Bool = false)
-        new(reuse_table, select, from, where, groupBy, orderBy, having, window_order, windowFrame, is_aggregated, 
+        ch_settings::String="", join_count::Int = 0, post_unnest::Bool = false, post_mutate::Bool = false, post_count::Bool = false)
+        new(reuse_table, fresh, select, from, where, groupBy, orderBy, having, window_order, windowFrame, is_aggregated, 
         post_aggregation, post_join, metadata, distinct, db, ctes, cte_count, athena_params, limit, ch_settings, join_count, post_unnest, post_mutate, post_count)
     end
 end
@@ -48,7 +50,6 @@ function from_query(query::TidierDB.SQLQuery)
     function copy(cte::TidierDB.CTE)
         return TidierDB.CTE(name=cte.name, select=cte.select, from=cte.from, where=cte.where, groupBy=cte.groupBy, having=cte.having)
     end
-    
     new_query = TidierDB.SQLQuery(
         select=query.select,
         from=query.from,

--- a/src/union_intersect_setdiff.jl
+++ b/src/union_intersect_setdiff.jl
@@ -88,8 +88,10 @@ macro union(sqlquery, union_query, args...)
     end
     return quote
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
         uq = isa($(esc(union_query)), String) ? $(esc(union_query)) : t($(esc(union_query))) 
  
         perform_set_operation(
@@ -107,8 +109,10 @@ $docstring_union_all
 macro union_all(sqlquery, union_query)
     return quote
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
         uq = isa($(esc(union_query)), String) ? $(esc(union_query)) : t($(esc(union_query))) 
  
         perform_set_operation(
@@ -136,8 +140,10 @@ macro intersect(sqlquery, union_query, args...)
 
     return quote
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
         uq = isa($(esc(union_query)), String) ? $(esc(union_query)) : t($(esc(union_query))) 
  
         perform_set_operation(
@@ -165,8 +171,10 @@ macro setdiff(sqlquery, union_query, args...)
 
     return quote
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
         uq = isa($(esc(union_query)), String) ? $(esc(union_query)) : t($(esc(union_query))) 
  
         

--- a/src/unnest.jl
+++ b/src/unnest.jl
@@ -48,8 +48,10 @@ macro unnest_wider(sqlquery, cols...)
     return quote
         # Evaluate the SQLQuery object.
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
         
         sq.post_unnest ? build_cte!(sq) : nothing
 
@@ -95,8 +97,10 @@ macro unnest_longer(sqlquery, cols...)
     return quote
         # Evaluate the SQLQuery object.
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
 
         sq.post_unnest ? build_cte!(sq) : nothing
         # Embed the list of column names as a literal vector.

--- a/src/windows.jl
+++ b/src/windows.jl
@@ -5,8 +5,10 @@ macro window_order(sqlquery, order_by_expr...)
 
     return quote
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
 
         if isa(sq, SQLQuery)
             # Convert order_by_expr to SQL order by string
@@ -98,8 +100,10 @@ macro window_frame(sqlquery, args...)
     # Now generate the code that computes the frame clauses at runtime
     return quote
         sq = $(esc(sqlquery))
-        sq = sq.reuse_table ? t($(esc(sqlquery))) : sq
+        sq = (sq.reuse_table || !sq.fresh) ? t($(esc(sqlquery))) : sq
         sq.reuse_table = false; 
+        sq.fresh = false;
+        
 
         if isa(sq, SQLQuery)
             # Evaluate frame_from_value and frame_to_value


### PR DESCRIPTION
Need to do some more testing still, but i think this removes the need for users to use `t` in all scenarios without making copies of the underlying query in every macro. 