### PR TITLE
add pivot longer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,10 @@
 # TidierDB.jl updates
+## v.8.6 - 2025-05-05
+- add `@pivot_longer`
+- resolve issue when calling `@summarize` consecutively 
+- permit `max`/`min` in addition to `maximum`/`minimum` 
+- add `count` to default aggregate function list
+
 ## v.8.5 - 2025-04-21
 - Fix macro hygeine `@mutate` warning with Pluto Notebooks
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TidierDB"
 uuid = "86993f9b-bbba-4084-97c5-ee15961ad48b"
 authors = ["Daniel Rizk <rizk.daniel.12@gmail.com> and contributors"]
-version = "0.8.5"
+version = "0.8.6"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/TidierDB.jl
+++ b/src/TidierDB.jl
@@ -18,7 +18,7 @@ using GZip
         @distinct, @left_join, @right_join, @inner_join, @count, @slice_max,  @union,
         @slice_min, @slice_sample, @rename, @relocate, @union_all, @setdiff, @intersect, 
         @semi_join, @full_join, @transmute,  @anti_join, @head,  @unnest_wider, @unnest_longer,
-        @separate, @unite, @drop_missing, @pivot_wider, @summary
+        @separate, @unite, @drop_missing, @pivot_wider, @pivot_longer, @summary
         
  export db_table, set_sql_mode, connect, from_query, update_con,  
  clickhouse, duckdb, sqlite, mysql, mssql, postgres, athena, snowflake, gbq, 

--- a/src/TidierDB.jl
+++ b/src/TidierDB.jl
@@ -41,7 +41,7 @@ using GZip
  struct databricks <: SQLBackend end
  
  const  _warning_ = Ref(false)
- const window_agg_fxns = [:lead, :lag, :dense_rank, :nth_value, :ntile, :rank_dense, :row_number, :first_value, :last_value, :cume_dist]
+ const window_agg_fxns = [:lead, :lag, :dense_rank, :nth_value, :ntile, :rank_dense, :row_number, :first_value, :last_value, :cume_dist, :count]
  current_sql_mode = Ref{SQLBackend}(duckdb())
  const color = Ref{Bool}(true)
  function set_sql_mode(mode::SQLBackend) current_sql_mode[] = mode end

--- a/src/TidierDB_macros.jl
+++ b/src/TidierDB_macros.jl
@@ -239,6 +239,7 @@ macro group_by(sqlquery, columns...)
                         orig[1] = replace(orig[1], "SELECT " => "")
                     end
                     sq.select = "SELECT " * join(vcat(group_expressions, orig), ", ")
+                    sq.select = replace(sq.select, " all," => "")
                 end
         else
             error("Expected sqlquery to be an instance of SQLQuery")

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -2244,7 +2244,7 @@ const docstring_pivot_wider =
 
 Reshapes the SQL_query to make it wider, increasing the number of columns and reducing the number of rows.
 
-`@pivot_wider` requires some eagerness to pul the disticnt values in the `names_from` columns. It will take the 
+`@pivot_wider` requires some eagerness to pull the disticnt values in the `names_from` columns. It will take the 
 query until the point of the `@pivot_wider`, and run a query to pull the disinct values in the `names_from` column
 
 # Arguments
@@ -2262,11 +2262,11 @@ julia> db = connect(duckdb()); dbdf = dt(db, df_long, "df");
 
 julia> @collect @pivot_wider(dbdf, names_from = variable, values_from = value)
 2×3 DataFrame
- Row │ id     A       B      
-     │ Int64  Int64?  Int64?
-─────┼───────────────────────
-   1 │     1       1       2
-   2 │     2       3       4
+ Row │ id     A      B     
+     │ Int64  Int64  Int64 
+─────┼─────────────────────
+   1 │     1      1      2
+   2 │     2      3      4
 
 julia> future_col_names = (:variable, [:A, :B]); 
 
@@ -2277,6 +2277,46 @@ julia> @eval @collect @pivot_wider(dbdf, names_from = \$future_col_names, values
 ─────┼─────────────────────
    1 │     1      1      2
    2 │     2      3      4
+```
+"""
+
+const docstring_pivot_longer =
+"""
+   @pivot_longer(df, names_from, values_from)
+
+Reshapes the SQL_query to make it longer, increasing the number of rows and reducing the number of columns.
+
+# Arguments
+- `sql_query`: The SQL query
+- `cols`: Columns to pivot into longer format. Multiple columns can be selected
+- `names_from`: Optional, defaults to variable. The name of the newly created column whose values will contain the input DataFrame's column names.
+- `values_from`:  Optional, defaults to value. The name of the newly created column containing the input DataFrame's cell values.
+
+# Examples
+```jldoctest
+julia> df = DataFrame(id = [1, 2], A = [1, 3], B = [2, 4]);
+
+julia> db = connect(duckdb()); df_wide = dt(db, df, "df");
+
+julia> @collect @pivot_longer(df_wide, A:B)
+4×3 DataFrame
+ Row │ id     variable  value 
+     │ Int64  String    Int64 
+─────┼────────────────────────
+   1 │     1  A             1
+   2 │     2  A             3
+   3 │     1  B             2
+   4 │     2  B             4
+
+julia> @collect @pivot_longer(df_wide, A:B, names_to = "letter", values_to = "number")
+4×3 DataFrame
+ Row │ id     letter  number 
+     │ Int64  String  Int64  
+─────┼───────────────────────
+   1 │     1  A            1
+   2 │     2  A            3
+   3 │     1  B            2
+   4 │     2  B            4
 ```
 """
 

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1888,7 +1888,7 @@ Nearly all aggregate functions from any database are supported both `@summarize`
 With `@summarize`, an aggregate functions available on a SQL backend can be used as they are in sql with the same syntax (`'` should be replaced with `"`)
 
 `@mutate` supports them as well, however, unless listed below, the function call must be wrapped with `agg()`
-- Aggregate Functions: `maximum`, `minimum`, `mean`, `std`, `sum`, `cumsum`
+- Aggregate Functions: `maximum`, `minimum`, `mean`, `std`, `sum`, `cumsum`, `count`
 - Window Functions: `lead`, `lag`, `dense_rank`, `nth_value`, `ntile`, `rank_dense`, `row_number`, `first_value`, `last_value`, `cume_dist`
 
 If a function is needed regularly, instead of wrapping it in `agg`, it can also be added to `window_agg_fxns` with `push!` as demonstrated below

--- a/src/mutate_and_summ.jl
+++ b/src/mutate_and_summ.jl
@@ -304,7 +304,10 @@ macro summarize(sqlquery, expressions...)
         if isa(sq, SQLQuery)
             summary_str = String[]
             sq.metadata.current_selxn .= 0
-
+            if sq.is_aggregated 
+                build_cte!(sq)
+                sq.select = ""
+            end
             # Set the grouping variable if `by` is provided
             if $(esc(grouping_var)) != nothing
                 group_vars = $(esc(grouping_var))
@@ -320,6 +323,7 @@ macro summarize(sqlquery, expressions...)
 
             # Update metadata for grouping columns
             if !isempty(sq.groupBy)
+                
                 groupby_columns = split(replace(sq.groupBy, "GROUP BY " => ""), ", ")
                 groupby_columns = strip.(groupby_columns)
                 for groupby_column in groupby_columns

--- a/src/parsing_athena.jl
+++ b/src/parsing_athena.jl
@@ -25,14 +25,14 @@ function expr_to_sql_trino(expr, sq; from_summarize::Bool)
                 window_clause = construct_window_clause(sq)
                 return  "***AVG($(string(a))) $(window_clause)***"
             end
-        elseif @capture(x, minimum(a_))
+        elseif @capture(x, minimum(a_)) || @capture(x, min(a_))
             if from_summarize
                 return :(MIN($a))
             else
                 window_clause = construct_window_clause(sq)
                 return  "***MIN($(string(a))) $(window_clause)***"
             end
-        elseif @capture(x, maximum(a_))
+        elseif @capture(x, maximum(a_)) || @capture(x, max(a_))
             if from_summarize
                 return :(MAX($a))
             else
@@ -62,10 +62,6 @@ function expr_to_sql_trino(expr, sq; from_summarize::Bool)
                 window_clause = construct_window_clause(sq, )
                 return  "STDDEV_SAMP($(string(a))) $(window_clause)"
             end
-        elseif @capture(x, max(a_))
-            error("To find the maximum, please use `maximum`, not `max`")
-        elseif @capture(x, min(a_))
-            error("To find the minimum, please use `minimum`, not `min`") 
         elseif isa(x, Expr) && x.head == :call && x.args[1] == :agg
             args = x.args[2:end]       # Capture all arguments to agg
             if from_summarize

--- a/src/parsing_athena.jl
+++ b/src/parsing_athena.jl
@@ -62,6 +62,10 @@ function expr_to_sql_trino(expr, sq; from_summarize::Bool)
                 window_clause = construct_window_clause(sq, )
                 return  "STDDEV_SAMP($(string(a))) $(window_clause)"
             end
+        elseif @capture(x, max(a_))
+            error("To find the maximum, please use `maximum`, not `max`")
+        elseif @capture(x, min(a_))
+            error("To find the minimum, please use `minimum`, not `min`") 
         elseif isa(x, Expr) && x.head == :call && x.args[1] == :agg
             args = x.args[2:end]       # Capture all arguments to agg
             if from_summarize

--- a/src/parsing_clickhouse.jl
+++ b/src/parsing_clickhouse.jl
@@ -25,14 +25,14 @@ function expr_to_sql_clickhouse(expr, sq; from_summarize::Bool)
                 window_clause = construct_window_clause(sq)
                 return  "***AVG($(string(a))) $(window_clause)***"
             end
-        elseif @capture(x, minimum(a_))
+        elseif @capture(x, minimum(a_)) || @capture(x, min(a_))
             if from_summarize
                 return :(MIN($a))
             else
                 window_clause = construct_window_clause(sq)
                 return  "***MIN($(string(a))) $(window_clause)***"
             end
-        elseif @capture(x, maximum(a_))
+        elseif @capture(x, maximum(a_)) || @capture(x, max(a_))
             if from_summarize
                 return :(MAX($a))
             else
@@ -54,10 +54,6 @@ function expr_to_sql_clickhouse(expr, sq; from_summarize::Bool)
                window_clause = construct_window_clause(sq, from_cumsum = true)
                return  "SUM($(string(a))) $(window_clause)"
             end
-        elseif @capture(x, max(a_))
-            error("To find the maximum, please use `maximum`, not `max`")
-        elseif @capture(x, min(a_))
-            error("To find the minimum, please use `minimum`, not `min`")
         #stats agg
         elseif @capture(x, std(a_))
             if from_summarize

--- a/src/parsing_clickhouse.jl
+++ b/src/parsing_clickhouse.jl
@@ -54,6 +54,10 @@ function expr_to_sql_clickhouse(expr, sq; from_summarize::Bool)
                window_clause = construct_window_clause(sq, from_cumsum = true)
                return  "SUM($(string(a))) $(window_clause)"
             end
+        elseif @capture(x, max(a_))
+            error("To find the maximum, please use `maximum`, not `max`")
+        elseif @capture(x, min(a_))
+            error("To find the minimum, please use `minimum`, not `min`")
         #stats agg
         elseif @capture(x, std(a_))
             if from_summarize

--- a/src/parsing_duckdb.jl
+++ b/src/parsing_duckdb.jl
@@ -56,6 +56,10 @@ function expr_to_sql_duckdb(expr, sq; from_summarize::Bool)
                window_clause = construct_window_clause(sq, from_cumsum = true)
                return  "***SUM($(string(a))) $(window_clause)***"
             end
+        elseif @capture(x, max(a_))
+            error("To find the maximum, please use `maximum`, not `max`") # COV_EXCL_LINE
+        elseif @capture(x, min(a_))
+            error("To find the minimum, please use `minimum`, not `min`") # COV_EXCL_LINE
         #stats agg
         elseif @capture(x, std(a_))
             if from_summarize

--- a/src/parsing_duckdb.jl
+++ b/src/parsing_duckdb.jl
@@ -27,14 +27,14 @@ function expr_to_sql_duckdb(expr, sq; from_summarize::Bool)
                 window_clause = construct_window_clause(sq)
                 return  "***AVG($(string(a))) $(window_clause)***"
             end
-        elseif @capture(x, minimum(a_))
+        elseif @capture(x, minimum(a_)) || @capture(x, min(a_))
             if from_summarize
                 return :(MIN($a))
             else
                 window_clause = construct_window_clause(sq)
                 return  "***MIN($(string(a))) $(window_clause)***"
             end
-        elseif @capture(x, maximum(a_))
+        elseif @capture(x, maximum(a_)) || @capture(x, max(a_))
             if from_summarize
                 return :(MAX($a))
             else
@@ -56,10 +56,6 @@ function expr_to_sql_duckdb(expr, sq; from_summarize::Bool)
                window_clause = construct_window_clause(sq, from_cumsum = true)
                return  "***SUM($(string(a))) $(window_clause)***"
             end
-        elseif @capture(x, max(a_))
-            error("To find the maximum, please use `maximum`, not `max`") # COV_EXCL_LINE
-        elseif @capture(x, min(a_))
-            error("To find the minimum, please use `minimum`, not `min`") # COV_EXCL_LINE
         #stats agg
         elseif @capture(x, std(a_))
             if from_summarize
@@ -91,7 +87,7 @@ function expr_to_sql_duckdb(expr, sq; from_summarize::Bool)
         elseif @capture(x, strremove(str_, pattern_))
             return :(REGEXP_REPLACE($str, $pattern, ""))
         elseif @capture(x, ismissing(a_))
-            return  "($(string(a)) IS NULL)"
+            return  "***($(string(a)) IS NULL)***"
         # Date extraction functions
         elseif @capture(x, column_[key_])
             # Convert variables to strings if necessary
@@ -102,18 +98,6 @@ function expr_to_sql_duckdb(expr, sq; from_summarize::Bool)
             else
                 return """ CASE WHEN $column_str IS NULL THEN NULL ELSE COALESCE(  LIST_EXTRACT( CASE  WHEN '$key_str' IS NULL THEN NULL ELSE ELEMENT_AT($column_str, '$key_str') END, 1 ), NULL) END ***"""
             end
-        elseif @capture(x, year(a_))
-            return "(__( EXTRACT(YEAR FROM " * string(a) * ") ***"
-        elseif @capture(x, month(a_))
-            return "(__( EXTRACT(MONTH FROM " * string(a) * ") ***"
-        elseif @capture(x, day(a_))
-            return "(__( EXTRACT(DAY FROM " * string(a) * ") ***"
-        elseif @capture(x, hour(a_))
-            return "(__( EXTRACT(HOUR FROM " * string(a) * ") ***"
-        elseif @capture(x, minute(a_))
-            return "(__( EXTRACT(MINUTE FROM " * string(a) * ") ***"
-        elseif @capture(x, second(a_))
-            return "(__( EXTRACT(SECOND FROM " * string(a) * ") ***"
         elseif @capture(x, Year(a_))
             return "(__( INTERVAL $(string(a)) Year )__("
         elseif @capture(x, Month(a_))

--- a/src/parsing_gbq.jl
+++ b/src/parsing_gbq.jl
@@ -54,6 +54,10 @@ function expr_to_sql_gbq(expr, sq; from_summarize::Bool)
                window_clause = construct_window_clause(sq, from_cumsum = true)
                return  "SUM($(string(a))) $(window_clause)"
             end
+        elseif @capture(x, max(a_))
+            error("To find the maximum, please use `maximum`, not `max`") # COV_EXCL_LINE
+        elseif @capture(x, min(a_))
+            error("To find the minimum, please use `minimum`, not `min`") # COV_EXCL_LINE
         #stats agg
         elseif @capture(x, std(a_))
             if from_summarize

--- a/src/parsing_gbq.jl
+++ b/src/parsing_gbq.jl
@@ -25,14 +25,14 @@ function expr_to_sql_gbq(expr, sq; from_summarize::Bool)
                 window_clause = construct_window_clause(sq)
                 return  "***AVG($(string(a))) $(window_clause)***"
             end
-        elseif @capture(x, minimum(a_))
+        elseif @capture(x, minimum(a_)) || @capture(x, min(a_))
             if from_summarize
                 return :(MIN($a))
             else
                 window_clause = construct_window_clause(sq)
                 return  "***MIN($(string(a))) $(window_clause)***"
             end
-        elseif @capture(x, maximum(a_))
+        elseif @capture(x, maximum(a_)) || @capture(x, max(a_))
             if from_summarize
                 return :(MAX($a))
             else
@@ -54,10 +54,6 @@ function expr_to_sql_gbq(expr, sq; from_summarize::Bool)
                window_clause = construct_window_clause(sq, from_cumsum = true)
                return  "SUM($(string(a))) $(window_clause)"
             end
-        elseif @capture(x, max(a_))
-            error("To find the maximum, please use `maximum`, not `max`") # COV_EXCL_LINE
-        elseif @capture(x, min(a_))
-            error("To find the minimum, please use `minimum`, not `min`") # COV_EXCL_LINE
         #stats agg
         elseif @capture(x, std(a_))
             if from_summarize

--- a/src/parsing_mssql.jl
+++ b/src/parsing_mssql.jl
@@ -54,6 +54,10 @@ function expr_to_sql_mssql(expr, sq; from_summarize::Bool)
                window_clause = construct_window_clause(sq, from_cumsum = true)
                return  "SUM($(string(a))) $(window_clause)"
             end
+        elseif @capture(x, max(a_))
+            error("To find the maximum, please use `maximum`, not `max`") # COV_EXCL_LINE
+        elseif @capture(x, min(a_))
+            error("To find the minimum, please use `minimum`, not `min`") # COV_EXCL_LINE
         #stats agg
         elseif @capture(x, std(a_))
             if from_summarize

--- a/src/parsing_mssql.jl
+++ b/src/parsing_mssql.jl
@@ -25,14 +25,14 @@ function expr_to_sql_mssql(expr, sq; from_summarize::Bool)
                 window_clause = construct_window_clause(sq)
                 return  "***AVG($(string(a))) $(window_clause)***"
             end
-        elseif @capture(x, minimum(a_))
+        elseif @capture(x, minimum(a_)) || @capture(x, min(a_))
             if from_summarize
                 return :(MIN($a))
             else
                 window_clause = construct_window_clause(sq)
                 return  "***MIN($(string(a))) $(window_clause)***"
             end
-        elseif @capture(x, maximum(a_))
+        elseif @capture(x, maximum(a_)) || @capture(x, max(a_))
             if from_summarize
                 return :(MAX($a))
             else
@@ -54,10 +54,7 @@ function expr_to_sql_mssql(expr, sq; from_summarize::Bool)
                window_clause = construct_window_clause(sq, from_cumsum = true)
                return  "SUM($(string(a))) $(window_clause)"
             end
-        elseif @capture(x, max(a_))
-            error("To find the maximum, please use `maximum`, not `max`") # COV_EXCL_LINE
-        elseif @capture(x, min(a_))
-            error("To find the minimum, please use `minimum`, not `min`") # COV_EXCL_LINE
+
         #stats agg
         elseif @capture(x, std(a_))
             if from_summarize

--- a/src/parsing_mysql.jl
+++ b/src/parsing_mysql.jl
@@ -54,6 +54,10 @@ function expr_to_sql_mysql(expr, sq; from_summarize::Bool)
                window_clause = construct_window_clause(sq, from_cumsum = true)
                return  "SUM($(string(a))) $(window_clause)"
             end
+        elseif @capture(x, max(a_))
+            error("To find the maximum, please use `maximum`, not `max`") # COV_EXCL_LINE
+        elseif @capture(x, min(a_))
+            error("To find the minimum, please use `minimum`, not `min`") # COV_EXCL_LINE
         #stats agg
         elseif @capture(x, std(a_))
             if from_summarize

--- a/src/parsing_mysql.jl
+++ b/src/parsing_mysql.jl
@@ -25,14 +25,14 @@ function expr_to_sql_mysql(expr, sq; from_summarize::Bool)
                 window_clause = construct_window_clause(sq)
                 return  "***AVG($(string(a))) $(window_clause)***"
             end
-        elseif @capture(x, minimum(a_))
+        elseif @capture(x, minimum(a_)) || @capture(x, min(a_))
             if from_summarize
                 return :(MIN($a))
             else
                 window_clause = construct_window_clause(sq)
                 return  "***MIN($(string(a))) $(window_clause)***"
             end
-        elseif @capture(x, maximum(a_))
+        elseif @capture(x, maximum(a_)) || @capture(x, max(a_))
             if from_summarize
                 return :(MAX($a))
             else
@@ -54,10 +54,7 @@ function expr_to_sql_mysql(expr, sq; from_summarize::Bool)
                window_clause = construct_window_clause(sq, from_cumsum = true)
                return  "SUM($(string(a))) $(window_clause)"
             end
-        elseif @capture(x, max(a_))
-            error("To find the maximum, please use `maximum`, not `max`") # COV_EXCL_LINE
-        elseif @capture(x, min(a_))
-            error("To find the minimum, please use `minimum`, not `min`") # COV_EXCL_LINE
+
         #stats agg
         elseif @capture(x, std(a_))
             if from_summarize

--- a/src/parsing_oracle.jl
+++ b/src/parsing_oracle.jl
@@ -25,14 +25,14 @@ function expr_to_sql_oracle(expr, sq; from_summarize::Bool)
                 window_clause = construct_window_clause(sq)
                 return  "***AVG($(string(a))) $(window_clause)***"
             end
-        elseif @capture(x, minimum(a_))
+        elseif @capture(x, minimum(a_)) || @capture(x, min(a_))
             if from_summarize
                 return :(MIN($a))
             else
                 window_clause = construct_window_clause(sq)
                 return  "***MIN($(string(a))) $(window_clause)***"
             end
-        elseif @capture(x, maximum(a_))
+        elseif @capture(x, maximum(a_)) || @capture(x, max(a_))
             if from_summarize
                 return :(MAX($a))
             else
@@ -54,10 +54,7 @@ function expr_to_sql_oracle(expr, sq; from_summarize::Bool)
                window_clause = construct_window_clause(sq, from_cumsum = true)
                return  "SUM($(string(a))) $(window_clause)"
             end
-        elseif @capture(x, max(a_))
-            error("To find the maximum, please use `maximum`, not `max`") # COV_EXCL_LINE
-        elseif @capture(x, min(a_))
-            error("To find the minimum, please use `minimum`, not `min`") # COV_EXCL_LINE
+
         #stats agg
         elseif @capture(x, std(a_))
             if from_summarize

--- a/src/parsing_oracle.jl
+++ b/src/parsing_oracle.jl
@@ -54,6 +54,10 @@ function expr_to_sql_oracle(expr, sq; from_summarize::Bool)
                window_clause = construct_window_clause(sq, from_cumsum = true)
                return  "SUM($(string(a))) $(window_clause)"
             end
+        elseif @capture(x, max(a_))
+            error("To find the maximum, please use `maximum`, not `max`") # COV_EXCL_LINE
+        elseif @capture(x, min(a_))
+            error("To find the minimum, please use `minimum`, not `min`") # COV_EXCL_LINE
         #stats agg
         elseif @capture(x, std(a_))
             if from_summarize

--- a/src/parsing_postgres.jl
+++ b/src/parsing_postgres.jl
@@ -54,6 +54,10 @@ function expr_to_sql_postgres(expr, sq; from_summarize::Bool)
                window_clause = construct_window_clause(sq, from_cumsum = true)
                return  "SUM($(string(a))) $(window_clause)"
             end
+        elseif @capture(x, max(a_))
+            error("To find the maximum, please use `maximum`, not `max`") # COV_EXCL_LINE
+        elseif @capture(x, min(a_))
+            error("To find the minimum, please use `minimum`, not `min`") # COV_EXCL_LINE
         #stats agg
         elseif @capture(x, std(a_))
             if from_summarize

--- a/src/parsing_postgres.jl
+++ b/src/parsing_postgres.jl
@@ -54,10 +54,7 @@ function expr_to_sql_postgres(expr, sq; from_summarize::Bool)
                window_clause = construct_window_clause(sq, from_cumsum = true)
                return  "SUM($(string(a))) $(window_clause)"
             end
-        elseif @capture(x, max(a_))
-            error("To find the maximum, please use `maximum`, not `max`") # COV_EXCL_LINE
-        elseif @capture(x, min(a_))
-            error("To find the minimum, please use `minimum`, not `min`") # COV_EXCL_LINE
+
         #stats agg
         elseif @capture(x, std(a_))
             if from_summarize

--- a/src/parsing_snowflake.jl
+++ b/src/parsing_snowflake.jl
@@ -55,6 +55,10 @@ function expr_to_sql_snowflake(expr, sq; from_summarize::Bool)
                window_clause = construct_window_clause(sq, from_cumsum = true)
                return  "SUM($(string(a))) $(window_clause)"
             end
+        elseif @capture(x, max(a_))
+            error("To find the maximum, please use `maximum`, not `max`") # COV_EXCL_LINE
+        elseif @capture(x, min(a_))
+            error("To find the minimum, please use `minimum`, not `min`") # COV_EXCL_LINE
         #stats agg
         elseif @capture(x, std(a_))
             if from_summarize

--- a/src/parsing_snowflake.jl
+++ b/src/parsing_snowflake.jl
@@ -55,10 +55,7 @@ function expr_to_sql_snowflake(expr, sq; from_summarize::Bool)
                window_clause = construct_window_clause(sq, from_cumsum = true)
                return  "SUM($(string(a))) $(window_clause)"
             end
-        elseif @capture(x, max(a_))
-            error("To find the maximum, please use `maximum`, not `max`") # COV_EXCL_LINE
-        elseif @capture(x, min(a_))
-            error("To find the minimum, please use `minimum`, not `min`") # COV_EXCL_LINE
+
         #stats agg
         elseif @capture(x, std(a_))
             if from_summarize

--- a/src/parsing_sqlite.jl
+++ b/src/parsing_sqlite.jl
@@ -67,10 +67,7 @@ function expr_to_sql_lite(expr, sq; from_summarize::Bool)
                 str = "$(arg_str)"
                 return "$(str) $(window_clause)"
             end
-        elseif @capture(x, max(a_))
-            error("To find the maximum, please use `maximum`, not `max`") # COV_EXCL_LINE
-        elseif @capture(x, min(a_))
-            error("To find the minimum, please use `minimum`, not `min`") # COV_EXCL_LINE
+
     # exc_capture_bug used above to allow proper _ function name capturing
         elseif @capture(x, replacemissing(column_, replacement_value_))
             return :(COALESCE($column, $replacement_value))

--- a/src/parsing_sqlite.jl
+++ b/src/parsing_sqlite.jl
@@ -67,6 +67,10 @@ function expr_to_sql_lite(expr, sq; from_summarize::Bool)
                 str = "$(arg_str)"
                 return "$(str) $(window_clause)"
             end
+        elseif @capture(x, max(a_))
+            error("To find the maximum, please use `maximum`, not `max`") # COV_EXCL_LINE
+        elseif @capture(x, min(a_))
+            error("To find the minimum, please use `minimum`, not `min`") # COV_EXCL_LINE
     # exc_capture_bug used above to allow proper _ function name capturing
         elseif @capture(x, replacemissing(column_, replacement_value_))
             return :(COALESCE($column, $replacement_value))

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -207,9 +207,10 @@ function finalize_query(sqlquery::SQLQuery)
     if current_sql_mode[] == postgres() || current_sql_mode[] == duckdb() || current_sql_mode[] == mysql() || current_sql_mode[] == mssql() || current_sql_mode[] == clickhouse() || current_sql_mode[] == athena() || current_sql_mode[] == gbq() || current_sql_mode[] == oracle()  || current_sql_mode[] == snowflake() || current_sql_mode[] == databricks()
         complete_query = replace(complete_query, "\"" => "'", "==" => "=")
     end
-    
         complete_query = current_sql_mode[] == postgres() ?  replace(complete_query, r"INTERVAL (\d+) ([a-zA-Z]+)" => s"INTERVAL '\1 \2'") : complete_query
-        complete_query = replace(complete_query, r"(?s)(\(SELECT\s+UNNEST.*?FROM\s+.*?\))" => s -> string(s) * ")")
+        complete_query = replace(complete_query, r"(?s)(\(SELECT\s+UNNEST.*?FROM\s+.*?\))" => s -> string(s) * ")",  "IS NULL) )'  AND" => "IS NULL) )  AND")
         
     return complete_query
 end
+
+


### PR DESCRIPTION
adds `pivot_longer`

```
julia> df_wide = DataFrame(id = [1, 2], A = [1, 3], B = [2, 4])
2×3 DataFrame
 Row │ id     A      B     
     │ Int64  Int64  Int64 
─────┼─────────────────────
   1 │     1      1      2
   2 │     2      3      4

julia> w =dt(db, df_wide, "wide");

julia> @chain w @pivot_longer( A:B, names_to = "letter", values_to = "number") @collect
4×3 DataFrame
 Row │ id     letter  number 
     │ Int64  String  Int64  
─────┼───────────────────────
   1 │     1  A            1
   2 │     2  A            3
   3 │     1  B            2
   4 │     2  B            4

julia> @chain w @pivot_longer(A:B) @collect
4×3 DataFrame
 Row │ id     variable  value 
     │ Int64  String    Int64 
─────┼────────────────────────
   1 │     1  A             1
   2 │     2  A             3
   3 │     1  B             2
   4 │     2  B             4
```